### PR TITLE
Test finished named

### DIFF
--- a/TcUnit/TcUnit/POUs/Functions/TEST_FINISHED.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/TEST_FINISHED.TcPOU
@@ -2,19 +2,23 @@
 <TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <POU Name="TEST_FINISHED" Id="{9922b45b-fca5-4323-be8f-93710371a816}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION TEST_FINISHED : BOOL
-VAR
-    TestName : Tc2_System.T_MaxString;
+VAR_INPUT
+	TestName : Tc2_System.T_MaxString := '';
+END_VAR
+VAR 
     Counter : UINT := 0;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[// Grab the currently running test name
-TestName := GVL_TcUnit.CurrentTestNameBeingCalled;
-
+IF TestName = '' THEN
+	TestName := GVL_TcUnit.CurrentTestNameBeingCalled;
+END_IF
+	
 TEST_FINISHED := FALSE;
 // Find the test suite and set the test as finished
 FOR Counter := 1 TO GVL_TcUnit.AmountOfInitializedTestSuites BY 1 DO
     IF GVL_TcUnit.TestSuiteAddresses[Counter] = GVL_TcUnit.CurrentTestSuiteBeingCalled THEN
-        GVL_TcUnit.TestSuiteAddresses[Counter]^.SetTestFinished(TestName := GVL_TcUnit.CurrentTestNameBeingCalled);
+        GVL_TcUnit.TestSuiteAddresses[Counter]^.SetTestFinished(TestName := TestName);
         TEST_FINISHED := TRUE;
         RETURN;
     END_IF
@@ -22,7 +26,9 @@ END_FOR]]></ST>
     </Implementation>
     <LineIds Name="TEST_FINISHED">
       <LineId Id="20" Count="0" />
+      <LineId Id="41" Count="0" />
       <LineId Id="8" Count="0" />
+      <LineId Id="42" Count="0" />
       <LineId Id="30" Count="0" />
       <LineId Id="21" Count="0" />
       <LineId Id="9" Count="0" />

--- a/TcUnit/TcUnit/POUs/Functions/TEST_FINISHED_NAMED.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/TEST_FINISHED_NAMED.TcPOU
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="TEST_FINISHED_NAMED" Id="{7a3926c3-51ee-4f1e-953f-089cfa833d72}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION TEST_FINISHED_NAMED : BOOL
+VAR_INPUT
+    TestName : Tc2_System.T_MaxString;
+END_VAR
+VAR
+    Counter : UINT := 0;
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[
+TEST_FINISHED_NAMED := FALSE;
+// Find the test suite and set the test as finished
+FOR Counter := 1 TO GVL_TcUnit.AmountOfInitializedTestSuites BY 1 DO
+    IF GVL_TcUnit.TestSuiteAddresses[Counter] = GVL_TcUnit.CurrentTestSuiteBeingCalled THEN
+        GVL_TcUnit.TestSuiteAddresses[Counter]^.SetTestFinished(TestName := TestName);
+        TEST_FINISHED_NAMED := TRUE;
+        RETURN;
+    END_IF
+END_FOR]]></ST>
+    </Implementation>
+    <LineIds Name="TEST_FINISHED_NAMED">
+      <LineId Id="30" Count="0" />
+      <LineId Id="21" Count="0" />
+      <LineId Id="9" Count="0" />
+      <LineId Id="16" Count="2" />
+      <LineId Id="31" Count="1" />
+      <LineId Id="19" Count="0" />
+      <LineId Id="15" Count="0" />
+    </LineIds>
+  </POU>
+</TcPlcObject>

--- a/TcUnit/TcUnit/TcUnit.plcproj
+++ b/TcUnit/TcUnit/TcUnit.plcproj
@@ -15,7 +15,7 @@
     <Implicit_Jitter_Distribution>{9ba5f403-6725-42f3-958a-e49cc23e0e00}</Implicit_Jitter_Distribution>
     <LibraryReferences>{d4c50e9b-48cc-4451-9f8a-44fa2a49ee45}</LibraryReferences>
     <CombineIds>false</CombineIds>
-    <Released>false</Released>
+    <Released>true</Released>
     <Title>TcUnit</Title>
     <DefaultNamespace>TcUnit</DefaultNamespace>
     <Description>TwinCAT unit testing framework.
@@ -32,7 +32,7 @@ Documentation and examples are available at www.tcunit.org</Description>
     </SelectedLibraryCategories>
     <Company>www.tcunit.org</Company>
     <Author>Jakob Sagatowski and contributors</Author>
-    <ProjectVersion>0.0.0.0</ProjectVersion>
+    <ProjectVersion>0.9.1.0</ProjectVersion>
     <!--    <OutputType>Exe</OutputType>
     <RootNamespace>MyApplication</RootNamespace>
     <AssemblyName>MyApplication</AssemblyName>-->

--- a/TcUnit/TcUnit/TcUnit.plcproj
+++ b/TcUnit/TcUnit/TcUnit.plcproj
@@ -15,7 +15,7 @@
     <Implicit_Jitter_Distribution>{9ba5f403-6725-42f3-958a-e49cc23e0e00}</Implicit_Jitter_Distribution>
     <LibraryReferences>{d4c50e9b-48cc-4451-9f8a-44fa2a49ee45}</LibraryReferences>
     <CombineIds>false</CombineIds>
-    <Released>true</Released>
+    <Released>false</Released>
     <Title>TcUnit</Title>
     <DefaultNamespace>TcUnit</DefaultNamespace>
     <Description>TwinCAT unit testing framework.
@@ -32,7 +32,7 @@ Documentation and examples are available at www.tcunit.org</Description>
     </SelectedLibraryCategories>
     <Company>www.tcunit.org</Company>
     <Author>Jakob Sagatowski and contributors</Author>
-    <ProjectVersion>0.9.1.0</ProjectVersion>
+    <ProjectVersion>0.0.0.0</ProjectVersion>
     <!--    <OutputType>Exe</OutputType>
     <RootNamespace>MyApplication</RootNamespace>
     <AssemblyName>MyApplication</AssemblyName>-->
@@ -127,6 +127,9 @@ Documentation and examples are available at www.tcunit.org</Description>
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Functions\TEST_FINISHED.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Functions\TEST_FINISHED_NAMED.TcPOU">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Version\Global_Version.TcGVL">


### PR DESCRIPTION
I was having issues getting TcUnit to recognize all tests were complete, and wait for all tests to register so I used a wrapper TEST and added a TEST_FINISHED_NAMED fun. to indicate when the wrapper test was complete. Also made another commit with just TEST_FINISHED so we don't have an extra function.

I ran TcVerifier but there are a lot of failed tests.