### PR TITLE
integrated  XmlControl/FileControl and exchanged FB_FormatString for Concat

### DIFF
--- a/TcUnit/TcUnit/DUTs/eXML.TcDUT
+++ b/TcUnit/TcUnit/DUTs/eXML.TcDUT
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <DUT Name="eXML" Id="{05a4fdda-1086-47b5-ad10-7c2bac568355}">
+    <Declaration><![CDATA[TYPE eXML :
+	(	
+		OK,
+		errMaxBufferLen,
+		errStringLen,
+		Error
+	);
+END_TYPE]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/TcUnit/TcUnit/GVLs/GVL_Param_XmlControl.TcGVL
+++ b/TcUnit/TcUnit/GVLs/GVL_Param_XmlControl.TcGVL
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <GVL Name="GVL_Param_XmlControl" Id="{69588962-bd3e-4958-957e-7bfb94609af1}" ParameterList="True">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+VAR_GLOBAL CONSTANT
+	udiMaxFileSize : UDINT := 4096;
+END_VAR]]></Declaration>
+  </GVL>
+</TcPlcObject>

--- a/TcUnit/TcUnit/GVLs/GVL_XmlControl.TcGVL
+++ b/TcUnit/TcUnit/GVLs/GVL_XmlControl.TcGVL
@@ -13,6 +13,8 @@ VAR_GLOBAL CONSTANT
 	sBackSlash : STRING[1] := '\';
 	sForwardSlash : STRING[1] := '/';
 	sNewLine : STRING[4] := '$R$L';
+	sOpenComment : STRING[5] := '<!-- ';
+	sCloseComment : STRING[4] := ' -->';
 END_VAR]]></Declaration>
   </GVL>
 </TcPlcObject>

--- a/TcUnit/TcUnit/GVLs/GVL_XmlControl.TcGVL
+++ b/TcUnit/TcUnit/GVLs/GVL_XmlControl.TcGVL
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <GVL Name="GVL_XmlControl" Id="{ddf8d934-a4f3-4b52-be50-09cc258232b0}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+VAR_GLOBAL CONSTANT
+	(* String Constants *)
+	sTagOpen : STRING[1] := '<';
+	sTagClose : STRING[3] := '>';
+	sEndTagClose : STRING[4] :='/>$R$L';
+	sSpace : STRING[1] :=' ';
+	sEQ : STRING[1] :='=';
+	sQuote : STRING[1] :='"';
+	sBackSlash : STRING[1] := '\';
+	sForwardSlash : STRING[1] := '/';
+	sNewLine : STRING[4] := '$R$L';
+END_VAR]]></Declaration>
+  </GVL>
+</TcPlcObject>

--- a/TcUnit/TcUnit/ITFs/I_FileControl.TcIO
+++ b/TcUnit/TcUnit/ITFs/I_FileControl.TcIO
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <Itf Name="I_FileControl" Id="{3c1c6669-bb89-4115-b308-e41ed973600e}">
+    <Declaration><![CDATA[INTERFACE I_FileControl
+]]></Declaration>
+    <Method Name="fileClose" Id="{d25f9c60-07f6-4d52-8216-ad46f022f682}">
+      <Declaration><![CDATA[// Close the current file
+METHOD fileClose : SysFile.SysTypes.RTS_IEC_RESULT;
+]]></Declaration>
+    </Method>
+    <Method Name="fileOpen" Id="{24558311-0f15-4c02-958d-c2f653ace999}">
+      <Declaration><![CDATA[// Opens a file
+METHOD fileOpen : SysFile.SysTypes.RTS_IEC_RESULT;
+VAR_INPUT
+	szFilename : STRING := 'filepath/output.xml'; // File name. File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/) and not with a Backslash (\)! 
+	stFileAccessMode : SysFile.ACCESS_MODE := SysFile.ACCESS_MODE.AM_APPEND_PLUS;
+END_VAR
+]]></Declaration>
+    </Method>
+    <Method Name="fileRead" Id="{cc91c0f8-c366-44ca-ae92-cbbb6d5f3d0a}">
+      <Declaration><![CDATA[METHOD fileRead : SysFile.SysTypes.RTS_IEC_RESULT;
+VAR_INPUT
+	// call with ADR( );
+	pString : POINTER TO BYTE;
+	// Call with SIZEOF( ); 
+	udiSizeOf : UDINT;
+END_VAR
+VAR_OUTPUT
+	// Filesize
+	Size : SysFile.SysTypes.RTS_IEC_SIZE;
+END_VAR]]></Declaration>
+    </Method>
+    <Method Name="fileSave" Id="{3442d30d-fe2c-4c18-9aff-91f1bfba0c45}">
+      <Declaration><![CDATA[// saves the contents of the buffer into a file
+// be sure to call fileOpen() before calling fileSave()
+METHOD fileSave : SysFile.SysTypes.RTS_IEC_RESULT;
+VAR_INPUT
+	// call with ADR( );
+	pString : POINTER TO BYTE;
+	// Call with SIZEOF( ); 
+	udiSizeOf : UDINT;
+END_VAR]]></Declaration>
+    </Method>
+  </Itf>
+</TcPlcObject>

--- a/TcUnit/TcUnit/ITFs/I_XmlControl.TcIO
+++ b/TcUnit/TcUnit/ITFs/I_XmlControl.TcIO
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <Itf Name="I_XmlControl" Id="{8393e1f7-c3a3-46ef-a368-e0ef06d0599c}">
+    <Declaration><![CDATA[INTERFACE I_XmlControl
+]]></Declaration>
+    <Method Name="ClearBuffer" Id="{28a93e9c-0211-48cd-993c-fa667dc6fe76}">
+      <Declaration><![CDATA[METHOD ClearBuffer : Bool
+VAR_INPUT
+END_VAR
+]]></Declaration>
+    </Method>
+    <Method Name="closeTag" Id="{89f56592-4a6c-4d73-9458-8aa189240754}">
+      <Declaration><![CDATA[METHOD closeTag : STRING
+VAR_INPUT
+END_VAR
+]]></Declaration>
+    </Method>
+    <Method Name="newComment" Id="{20e2ebb6-9c42-4d16-8ed7-7959411a65a6}">
+      <Declaration><![CDATA[METHOD newComment : BOOL
+VAR_INPUT
+	sCommand : STRING;
+END_VAR
+]]></Declaration>
+    </Method>
+    <Method Name="newPara" Id="{16bdd25c-3bea-429a-bca6-fc93fb93e577}">
+      <Declaration><![CDATA[METHOD newPara : BOOL
+VAR_INPUT
+	sParaName : STRING;
+	sValue : STRING;	
+END_VAR
+]]></Declaration>
+    </Method>
+    <Method Name="newTag" Id="{94ad0e99-1e1c-41c3-aaa9-138159f2ef8f}">
+      <Declaration><![CDATA[METHOD newTag : BOOL
+VAR_INPUT
+	sTagName : STRING;
+END_VAR
+]]></Declaration>
+    </Method>
+    <Method Name="newTagData" Id="{a364dcbb-b527-4dd0-9210-7a276e7c3028}">
+      <Declaration><![CDATA[METHOD newTagData : BOOL
+VAR_INPUT
+	sTagData : STRING;
+END_VAR
+]]></Declaration>
+    </Method>
+    <Method Name="NextPara" Id="{c65caba9-5dfe-4795-835e-26e943c8b72e}">
+      <Declaration><![CDATA[METHOD NextPara : STRING;
+VAR_OUTPUT
+	sPara : STRING;	
+END_VAR
+]]></Declaration>
+    </Method>
+    <Method Name="NextTag" Id="{f719f6d0-84d1-4e62-ac42-152d9fb9d7df}">
+      <Declaration><![CDATA[METHOD NextTag : STRING
+VAR_INPUT
+END_VAR
+]]></Declaration>
+    </Method>
+    <Method Name="SetBuffer" Id="{68c320d4-d556-4945-8daa-c3c5a8305f52}">
+      <Declaration><![CDATA[METHOD SetBuffer : BOOL
+VAR_INPUT
+	pString : POINTER TO BYTE;
+	iSizeOf : UDINT;
+END_VAR
+]]></Declaration>
+    </Method>
+    <Method Name="ToStartBuffer" Id="{ecdf2beb-07bc-4c3b-86d9-084a1c71653b}">
+      <Declaration><![CDATA[METHOD ToStartBuffer
+VAR_INPUT
+END_VAR
+]]></Declaration>
+    </Method>
+    <Method Name="writeDocumentHeader" Id="{7314635f-681c-4c5b-a43f-17408892397c}">
+      <Declaration><![CDATA[(*
+	add your own preffered header like;
+	'<?xml version=\"1.0\" encoding=\"UTF-8\"?>'
+*)
+METHOD writeDocumentHeader
+VAR_INPUT
+	strHeader : STRING;
+END_VAR
+]]></Declaration>
+    </Method>
+  </Itf>
+</TcPlcObject>

--- a/TcUnit/TcUnit/POUs/FB_FileControl.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_FileControl.TcPOU
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_FileControl" Id="{92b054f5-6c17-4a97-bba0-430785a7dda3}" SpecialFunc="None">
+    <Declaration><![CDATA[{attribute 'hide_all_locals'}
+FUNCTION_BLOCK FB_FileControl IMPLEMENTS I_FileControl
+VAR
+	stFileAccessMode : SysFile.ACCESS_MODE := SysFile.AM_WRITE_PLUS;
+	hFile : SysFile.SysTypes.RTS_IEC_HANDLE;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[]]></ST>
+    </Implementation>
+    <Method Name="fileClose" Id="{9e59e2f2-4c01-4eef-a03e-ca6cece47c41}">
+      <Declaration><![CDATA[// Close the current file
+METHOD fileClose : SysFile.SysTypes.RTS_IEC_RESULT;
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[IF hFile <> SysFile.SysTypes.RTS_INVALID_HANDLE THEN
+	fileClose := SysFile.SysFileClose(hFile := hFile);
+END_IF]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="fileOpen" Id="{edeba3e3-eab7-4baf-8c37-097da76a12ae}">
+      <Declaration><![CDATA[// Opens a file
+METHOD fileOpen : SysFile.SysTypes.RTS_IEC_RESULT;
+VAR_INPUT
+	// File name. File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)
+	szFilename : STRING := 'filepath/output.xml'; 
+	stFileAccessMode : SysFile.ACCESS_MODE := SysFile.ACCESS_MODE.AM_APPEND_PLUS;
+END_VAR]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[hFile := SysFile.SysFileOpen( szFile := szFilename,
+							  am := stFileAccessMode,
+							  pResult := ADR(fileOpen));]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="fileRead" Id="{f93ea44f-4d8d-464c-9dd2-7b8491d1d0cf}">
+      <Declaration><![CDATA[METHOD fileRead  : SysFile.SysTypes.RTS_IEC_RESULT;
+VAR_INPUT
+	// Call with ADR( );
+	pString : POINTER TO BYTE;
+	// Call with SIZEOF( ); 
+	udiSizeOf : UDINT;
+END_VAR
+VAR_OUTPUT
+	// Filesize
+	Size : SysFile.SysTypes.RTS_IEC_SIZE;
+END_VAR]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[IF hFile <> SysFile.SysTypes.RTS_INVALID_HANDLE THEN
+	Size := SysFile.SysFileread(hFile := hFile, 
+							pbyBuffer := pString,
+							ulSize := udiSizeOf, 
+							pResult := ADR(fileRead));					
+END_IF]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="fileSave" Id="{2f313ee5-51e4-4400-81ec-246d44b99c29}">
+      <Declaration><![CDATA[// saves the contents of the buffer into a file
+// be sure to call fileOpen() before calling fileSave()
+METHOD fileSave : SysFile.SysTypes.RTS_IEC_RESULT;
+VAR_INPUT
+	// call with ADR( );
+	pString : POINTER TO BYTE;
+	// Call with SIZEOF( ); 
+	udiSizeOf : UDINT;
+END_VAR]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[IF hFile <> SysFile.SysTypes.RTS_INVALID_HANDLE THEN
+	SysFile.SysFileWrite(hFile := hFile, 
+						pbyBuffer := pString,
+						ulSize := udiSizeOf, 
+						pResult := ADR(fileSave));					
+END_IF]]></ST>
+      </Implementation>
+    </Method>
+    <LineIds Name="FB_FileControl">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_FileControl.fileClose">
+      <LineId Id="3" Count="1" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_FileControl.fileOpen">
+      <LineId Id="3" Count="1" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_FileControl.fileRead">
+      <LineId Id="3" Count="4" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_FileControl.fileSave">
+      <LineId Id="3" Count="4" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+  </POU>
+</TcPlcObject>

--- a/TcUnit/TcUnit/POUs/FB_TestSuite.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_TestSuite.TcPOU
@@ -174,9 +174,6 @@ VAR
     ActualArrayIndex : ARRAY[1..2] OF DINT; // Array of current Actual array indexes when looping through arrays
     Expected : LREAL; // Single expected value
     Actual : LREAL; // Single actual value
-    ExpectedValueString : Tc2_System.T_MaxString;
-    ActualValueString : Tc2_System.T_MaxString;
-    FormatString : Tc2_Utilities.FB_FormatString; // String formatter for output messages
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
@@ -250,42 +247,78 @@ IF NOT AlreadyReported AND NOT Equals THEN
 
     IF NOT SizeEquals THEN
         Message := Tc2_Standard.CONCAT(STR1 := Message, STR2 := ', size of arrays not matching.');
-        ExpectedString := 'SIZE = ';
-        FormatString(
-            sFormat := 'SIZE = [%d..%d,%d..%d] (%dx%d)',
-            arg1 := F_DINT(LowerBoundExpecteds[1]),
-            arg2 := F_DINT(UpperBoundExpecteds[1]),
-            arg3 := F_DINT(LowerBoundExpecteds[2]),
-            arg4 := F_DINT(UpperBoundExpecteds[2]),
-            arg5 := F_DINT(SizeOfExpecteds[1]),
-            arg6 := F_DINT(SizeOfExpecteds[2]),
-            sOut => ExpectedString);
+        //ExpectedString := 'SIZE = ';
+        //FormatString(
+        //    sFormat := 'SIZE = [%d..%d,%d..%d] (%dx%d)',
+        //    arg1 := F_DINT(LowerBoundExpecteds[1]),
+        //    arg2 := F_DINT(UpperBoundExpecteds[1]),
+        //    arg3 := F_DINT(LowerBoundExpecteds[2]),
+        //    arg4 := F_DINT(UpperBoundExpecteds[2]),
+        //    arg5 := F_DINT(SizeOfExpecteds[1]),
+        //    arg6 := F_DINT(SizeOfExpecteds[2]),
+        //    sOut => ExpectedString);
+		ExpectedString := 'SIZE = [';		 
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(LowerBoundExpecteds[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '..');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(UpperBoundExpecteds[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ',');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(LowerBoundExpecteds[2]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '..');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(UpperBoundExpecteds[2]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '] (');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(SizeOfExpecteds[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := 'x');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(SizeOfExpecteds[2]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ')');
 
-        FormatString(
-            sFormat := 'SIZE = [%d..%d,%d..%d] (%dx%d)',
-            arg1 := F_DINT(LowerBoundActuals[1]),
-            arg2 := F_DINT(UpperBoundActuals[1]),
-            arg3 := F_DINT(LowerBoundActuals[2]),
-            arg4 := F_DINT(UpperBoundActuals[2]),
-            arg5 := F_DINT(SizeOfActuals[1]),
-            arg6 := F_DINT(SizeOfActuals[2]),
-            sOut => ActualString);
-    ELSE
-        ExpectedValueString := LREAL_TO_STRING(Expected);
-        ActualValueString := LREAL_TO_STRING(Actual);
-        FormatString(
-            sFormat := 'ARRAY[%d,%d] = %s',
-            arg1 := F_DINT(ExpectedArrayIndex[1]),
-            arg2 := F_DINT(ExpectedArrayIndex[2]),
-            arg3 := F_STRING(ExpectedValueString),
-            sOut => ExpectedString);
-
-        FormatString(
-            sFormat := 'ARRAY[%d,%d] = %s',
-            arg1 := F_DINT(ActualArrayIndex[1]),
-            arg2 := F_DINT(ActualArrayIndex[2]),
-            arg3 := F_STRING(ActualValueString),
-            sOut => ActualString);
+        //FormatString(
+        //    sFormat := 'SIZE = [%d..%d,%d..%d] (%dx%d)',
+        //    arg1 := F_DINT(LowerBoundActuals[1]),
+        //    arg2 := F_DINT(UpperBoundActuals[1]),
+        //    arg3 := F_DINT(LowerBoundActuals[2]),
+        //    arg4 := F_DINT(UpperBoundActuals[2]),
+        //    arg5 := F_DINT(SizeOfActuals[1]),
+        //    arg6 := F_DINT(SizeOfActuals[2]),
+        //    sOut => ActualString);
+		ActualString := 'SIZE = [';		 
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(LowerBoundActuals[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '..');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(UpperBoundActuals[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ',');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(LowerBoundActuals[2]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '..');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(UpperBoundActuals[2]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '] (');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(SizeOfActuals[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := 'x');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(SizeOfActuals[2]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ')');
+    ELSE       
+		//FormatString(
+        //    sFormat := 'ARRAY[%d,%d] = %s',
+        //    arg1 := F_DINT(ExpectedArrayIndex[1]),
+        //    arg2 := F_DINT(ExpectedArrayIndex[2]),
+        //    arg3 := F_STRING(LREAL_TO_STRING(Expected)),
+        //   sOut => ExpectedString);
+		ExpectedString := 'ARRAY[';
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(ExpectedArrayIndex[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ',');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(ExpectedArrayIndex[2]));	
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '] = ');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := LREAL_TO_STRING(Expected));
+		
+        //FormatString(
+        //    sFormat := 'ARRAY[%d,%d] = %s',
+        //    arg1 := F_DINT(ActualArrayIndex[1]),
+        //    arg2 := F_DINT(ActualArrayIndex[2]),
+        //    arg3 := F_STRING(LREAL_TO_STRING(Actual)),
+        //    sOut => ActualString);
+		ActualString := 'ARRAY[';
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(ActualArrayIndex[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ',');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(ActualArrayIndex[2]));	
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '] = ');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := LREAL_TO_STRING(Actual));
     END_IF
 
     AssertMessageFormatter.LogAssertFailure(Expected := ExpectedString,
@@ -324,9 +357,6 @@ VAR
     ActualArrayIndex : ARRAY[1..2] OF DINT; // Array of current Actual array indexes when looping through arrays
     Expected : REAL; // Single expected value
     Actual : REAL; // Single actual value
-    ExpectedValueString : Tc2_System.T_MaxString;
-    ActualValueString : Tc2_System.T_MaxString;
-    FormatString : Tc2_Utilities.FB_FormatString;// String formatter for output messages
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
@@ -400,42 +430,81 @@ IF NOT AlreadyReported AND NOT Equals THEN
 
     IF NOT SizeEquals THEN
         Message := Tc2_Standard.CONCAT(STR1 := Message, STR2 := ', size of arrays not matching.');
-        ExpectedString := 'SIZE = ';
-        FormatString(
-            sFormat := 'SIZE = [%d..%d,%d..%d] (%dx%d)',
-            arg1 := F_DINT(LowerBoundExpecteds[1]),
-            arg2 := F_DINT(UpperBoundExpecteds[1]),
-            arg3 := F_DINT(LowerBoundExpecteds[2]),
-            arg4 := F_DINT(UpperBoundExpecteds[2]),
-            arg5 := F_DINT(SizeOfExpecteds[1]),
-            arg6 := F_DINT(SizeOfExpecteds[2]),
-            sOut => ExpectedString);
+        //ExpectedString := 'SIZE = ';
+        //FormatString(
+        //    sFormat := 'SIZE = [%d..%d,%d..%d] (%dx%d)',
+        //    arg1 := F_DINT(LowerBoundExpecteds[1]),
+        //    arg2 := F_DINT(UpperBoundExpecteds[1]),
+        //    arg3 := F_DINT(LowerBoundExpecteds[2]),
+        //    arg4 := F_DINT(UpperBoundExpecteds[2]),
+        //    arg5 := F_DINT(SizeOfExpecteds[1]),
+        //    arg6 := F_DINT(SizeOfExpecteds[2]),
+        //    sOut => ExpectedString);
+		ExpectedString := 'SIZE = [';		 
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(LowerBoundExpecteds[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '..');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(UpperBoundExpecteds[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ',');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(LowerBoundExpecteds[2]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '..');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(UpperBoundExpecteds[2]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '] (');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(SizeOfExpecteds[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := 'x');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(SizeOfExpecteds[2]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ')');		
 
-        FormatString(
-            sFormat := 'SIZE = [%d..%d,%d..%d] (%dx%d)',
-            arg1 := F_DINT(LowerBoundActuals[1]),
-            arg2 := F_DINT(UpperBoundActuals[1]),
-            arg3 := F_DINT(LowerBoundActuals[2]),
-            arg4 := F_DINT(UpperBoundActuals[2]),
-            arg5 := F_DINT(SizeOfActuals[1]),
-            arg6 := F_DINT(SizeOfActuals[2]),
-            sOut => ActualString);
+        //FormatString(
+        //    sFormat := 'SIZE = [%d..%d,%d..%d] (%dx%d)',
+        //    arg1 := F_DINT(LowerBoundActuals[1]),
+        //    arg2 := F_DINT(UpperBoundActuals[1]),
+        //    arg3 := F_DINT(LowerBoundActuals[2]),
+        //    arg4 := F_DINT(UpperBoundActuals[2]),
+        //    arg5 := F_DINT(SizeOfActuals[1]),
+        //    arg6 := F_DINT(SizeOfActuals[2]),
+        //    sOut => ActualString);
+		ActualString := 'SIZE = [';		 
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(LowerBoundActuals[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '..');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(UpperBoundActuals[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ',');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(LowerBoundActuals[2]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '..');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(UpperBoundActuals[2]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '] (');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(SizeOfActuals[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := 'x');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(SizeOfActuals[2]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ')');	   
+	   
     ELSE
-        ExpectedValueString := REAL_TO_STRING(Expected);
-        ActualValueString := REAL_TO_STRING(Actual);
-        FormatString( 
-            sFormat := 'ARRAY[%d,%d] = %s',
-            arg1 := F_DINT(ExpectedArrayIndex[1]),
-            arg2 := F_DINT(ExpectedArrayIndex[2]),
-            arg3 := F_STRING(ExpectedValueString),
-            sOut => ExpectedString);
+        //ExpectedValueString := REAL_TO_STRING(Expected);
+        //ActualValueString := REAL_TO_STRING(Actual);
+        //FormatString( 
+        //    sFormat := 'ARRAY[%d,%d] = %s',
+        //    arg1 := F_DINT(ExpectedArrayIndex[1]),
+        //    arg2 := F_DINT(ExpectedArrayIndex[2]),
+        //    arg3 := F_STRING(ExpectedValueString),
+        //    sOut => ExpectedString);
+		ExpectedString := 'ARRAY[';
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(ExpectedArrayIndex[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ',');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(ExpectedArrayIndex[2]));	
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '] = ');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := REAL_TO_STRING(Expected));	   
 
-        FormatString( 
-            sFormat := 'ARRAY[%d,%d] = %s',
-            arg1 := F_DINT(ActualArrayIndex[1]),
-            arg2 := F_DINT(ActualArrayIndex[2]),
-            arg3 := F_STRING(ActualValueString),
-            sOut => ActualString);
+        //FormatString( 
+        //    sFormat := 'ARRAY[%d,%d] = %s',
+        //    arg1 := F_DINT(ActualArrayIndex[1]),
+        //    arg2 := F_DINT(ActualArrayIndex[2]),
+        //    arg3 := F_STRING(ActualValueString),
+        //    sOut => ActualString);
+		ActualString := 'ARRAY[';
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(ActualArrayIndex[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ',');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(ActualArrayIndex[2]));	
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '] = ');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := REAL_TO_STRING(Actual));	   
     END_IF
 
     AssertMessageFormatter.LogAssertFailure(Expected := ExpectedString,
@@ -474,9 +543,6 @@ VAR
     ActualArrayIndex : ARRAY[1..3] OF DINT; // Array of current Actual array indexes when looping through arrays
     Expected : LREAL; // Single expected value
     Actual : LREAL; // Single actual value
-    ExpectedValueString : Tc2_System.T_MaxString;
-    ActualValueString : Tc2_System.T_MaxString;
-    FormatString : Tc2_Utilities.FB_FormatString; // String formatter for output messages
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
@@ -561,50 +627,104 @@ IF NOT AlreadyReported AND NOT Equals THEN
 
     IF NOT SizeEquals THEN
         Message := CONCAT(STR1 := Message, STR2 := ', size of arrays not matching.');
-        ExpectedString := 'SIZE = ';
-        FormatString(
-            sFormat := 'SIZE = [%d..%d,%d..%d,%d..%d] (%dx%dx%d)',
-            arg1 := F_DINT(LowerBoundExpecteds[1]),
-            arg2 := F_DINT(UpperBoundExpecteds[1]),
-            arg3 := F_DINT(LowerBoundExpecteds[2]),
-            arg4 := F_DINT(UpperBoundExpecteds[2]),
-            arg5 := F_DINT(LowerBoundExpecteds[3]),
-            arg6 := F_DINT(UpperBoundExpecteds[3]),
-            arg7 := F_DINT(SizeOfExpecteds[1]),
-            arg8 := F_DINT(SizeOfExpecteds[2]),
-            arg9 := F_DINT(SizeOfExpecteds[3]),
-            sOut => ExpectedString);
+        //ExpectedString := 'SIZE = ';
+        //FormatString(
+        //    sFormat := 'SIZE = [%d..%d,%d..%d,%d..%d] (%dx%dx%d)',
+        //    arg1 := F_DINT(LowerBoundExpecteds[1]),
+        //    arg2 := F_DINT(UpperBoundExpecteds[1]),
+        //    arg3 := F_DINT(LowerBoundExpecteds[2]),
+        //    arg4 := F_DINT(UpperBoundExpecteds[2]),
+        //    arg5 := F_DINT(LowerBoundExpecteds[3]),
+        //    arg6 := F_DINT(UpperBoundExpecteds[3]),
+        //    arg7 := F_DINT(SizeOfExpecteds[1]),
+        //    arg8 := F_DINT(SizeOfExpecteds[2]),
+        //    arg9 := F_DINT(SizeOfExpecteds[3]),
+        //    sOut => ExpectedString);
+		ExpectedString := 'SIZE = [';
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(LowerBoundExpecteds[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '..');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(UpperBoundExpecteds[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ',');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(LowerBoundExpecteds[2]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '..');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(UpperBoundExpecteds[2]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ',');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(LowerBoundExpecteds[3]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '..');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(UpperBoundExpecteds[3]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '] (');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(SizeOfExpecteds[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := 'x');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(SizeOfExpecteds[2]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := 'x');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(SizeOfExpecteds[3]));	
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ')');
 
-        FormatString(
-            sFormat := 'SIZE = [%d..%d,%d..%d,%d..%d] (%dx%dx%d)',
-            arg1 := F_DINT(LowerBoundActuals[1]),
-            arg2 := F_DINT(UpperBoundActuals[1]),
-            arg3 := F_DINT(LowerBoundActuals[2]),
-            arg4 := F_DINT(UpperBoundActuals[2]),
-            arg5 := F_DINT(LowerBoundActuals[3]),
-            arg6 := F_DINT(UpperBoundActuals[3]),
-            arg7 := F_DINT(SizeOfActuals[1]),
-            arg8 := F_DINT(SizeOfActuals[2]),
-            arg9 := F_DINT(SizeOfActuals[3]),
-            sOut => ActualString);
+        //FormatString(
+        //    sFormat := 'SIZE = [%d..%d,%d..%d,%d..%d] (%dx%dx%d)',
+        //    arg1 := F_DINT(LowerBoundActuals[1]),
+        //    arg2 := F_DINT(UpperBoundActuals[1]),
+        //    arg3 := F_DINT(LowerBoundActuals[2]),
+        //    arg4 := F_DINT(UpperBoundActuals[2]),
+        //    arg5 := F_DINT(LowerBoundActuals[3]),
+        //    arg6 := F_DINT(UpperBoundActuals[3]),
+        //    arg7 := F_DINT(SizeOfActuals[1]),
+        //    arg8 := F_DINT(SizeOfActuals[2]),
+        //    arg9 := F_DINT(SizeOfActuals[3]),
+        //    sOut => ActualString);
+		ActualString := 'SIZE = [';
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(LowerBoundActuals[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '..');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(UpperBoundActuals[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ',');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(LowerBoundActuals[2]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '..');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(UpperBoundActuals[2]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ',');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(LowerBoundActuals[3]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '..');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(UpperBoundActuals[3]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '] (');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(SizeOfActuals[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := 'x');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(SizeOfActuals[2]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := 'x');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(SizeOfActuals[3]));	
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ')');		
     ELSE
-        ExpectedValueString := LREAL_TO_STRING(Expected);
-        ActualValueString := LREAL_TO_STRING(Actual);
-        FormatString( 
-            sFormat := 'ARRAY[%d,%d,%d] = %s',
-            arg1 := F_DINT(ExpectedArrayIndex[1]),
-            arg2 := F_DINT(ExpectedArrayIndex[2]),
-            arg3 := F_DINT(ExpectedArrayIndex[3]),
-            arg4 := F_STRING(ExpectedValueString),
-            sOut => ExpectedString);
+       //ExpectedValueString := LREAL_TO_STRING(Expected);
+        //ActualValueString := LREAL_TO_STRING(Actual);
+        //FormatString( 
+        //    sFormat := 'ARRAY[%d,%d,%d] = %s',
+        //    arg1 := F_DINT(ExpectedArrayIndex[1]),
+        //    arg2 := F_DINT(ExpectedArrayIndex[2]),
+        //    arg3 := F_DINT(ExpectedArrayIndex[3]),
+        //    arg4 := F_STRING(ExpectedValueString),
+        //    sOut => ExpectedString);
+		ExpectedString := 'ARRAY[';
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(ExpectedArrayIndex[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ',');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(ExpectedArrayIndex[2]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ',');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(ExpectedArrayIndex[3]));		
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '] = ');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := LREAL_TO_STRING(Expected) );		
 
-        FormatString( 
-            sFormat := 'ARRAY[%d,%d,%d] = %s',
-            arg1 := F_DINT(ActualArrayIndex[1]),
-            arg2 := F_DINT(ActualArrayIndex[2]),
-            arg3 := F_DINT(ActualArrayIndex[3]),
-            arg4 := F_STRING(ActualValueString),
-            sOut => ActualString);
+        // FormatString( 
+        //     sFormat := 'ARRAY[%d,%d,%d] = %s',
+        //     arg1 := F_DINT(ActualArrayIndex[1]),
+        //     arg2 := F_DINT(ActualArrayIndex[2]),
+        //     arg3 := F_DINT(ActualArrayIndex[3]),
+        //     arg4 := F_STRING(ActualValueString),
+        //     sOut => ActualString);	
+		ActualString := 'ARRAY[';
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(ActualArrayIndex[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ',');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(ActualArrayIndex[2]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ',');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(ActualArrayIndex[3]));	
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '] = ');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := LREAL_TO_STRING(Actual));
     END_IF
 
     AssertMessageFormatter.LogAssertFailure(Expected := ExpectedString,
@@ -731,49 +851,103 @@ IF NOT AlreadyReported AND NOT Equals THEN
     IF NOT SizeEquals THEN
         Message := CONCAT(STR1 := Message, STR2 := ', size of arrays not matching.');
         ExpectedString := 'SIZE = ';
-        FormatString(
-            sFormat := 'SIZE = [%d..%d,%d..%d,%d..%d] (%dx%dx%d)',
-            arg1 := F_DINT(LowerBoundExpecteds[1]),
-            arg2 := F_DINT(UpperBoundExpecteds[1]),
-            arg3 := F_DINT(LowerBoundExpecteds[2]),
-            arg4 := F_DINT(UpperBoundExpecteds[2]),
-            arg5 := F_DINT(LowerBoundExpecteds[3]),
-            arg6 := F_DINT(UpperBoundExpecteds[3]),
-            arg7 := F_DINT(SizeOfExpecteds[1]),
-            arg8 := F_DINT(SizeOfExpecteds[2]),
-            arg9 := F_DINT(SizeOfExpecteds[3]),
-            sOut => ExpectedString);
-
-        FormatString( 
-            sFormat := 'SIZE = [%d..%d,%d..%d,%d..%d] (%dx%dx%d)',
-            arg1 := F_DINT(LowerBoundActuals[1]),
-            arg2 := F_DINT(UpperBoundActuals[1]),
-            arg3 := F_DINT(LowerBoundActuals[2]),
-            arg4 := F_DINT(UpperBoundActuals[2]),
-            arg5 := F_DINT(LowerBoundActuals[3]),
-            arg6 := F_DINT(UpperBoundActuals[3]),
-            arg7 := F_DINT(SizeOfActuals[1]),
-            arg8 := F_DINT(SizeOfActuals[2]),
-            arg9 := F_DINT(SizeOfActuals[3]),
-            sOut => ActualString);
+        //FormatString(
+        //    sFormat := 'SIZE = [%d..%d,%d..%d,%d..%d] (%dx%dx%d)',
+        //    arg1 := F_DINT(LowerBoundExpecteds[1]),
+        //    arg2 := F_DINT(UpperBoundExpecteds[1]),
+        //    arg3 := F_DINT(LowerBoundExpecteds[2]),
+        //    arg4 := F_DINT(UpperBoundExpecteds[2]),
+        //    arg5 := F_DINT(LowerBoundExpecteds[3]),
+        //    arg6 := F_DINT(UpperBoundExpecteds[3]),
+        //    arg7 := F_DINT(SizeOfExpecteds[1]),
+        //    arg8 := F_DINT(SizeOfExpecteds[2]),
+        //    arg9 := F_DINT(SizeOfExpecteds[3]),
+        //    sOut => ExpectedString);
+		ExpectedString := 'SIZE = [';
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(LowerBoundExpecteds[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '..');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(UpperBoundExpecteds[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ',');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(LowerBoundExpecteds[2]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '..');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(UpperBoundExpecteds[2]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ',');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(LowerBoundExpecteds[3]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '..');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(UpperBoundExpecteds[3]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '] (');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(SizeOfExpecteds[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := 'x');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(SizeOfExpecteds[2]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := 'x');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(SizeOfExpecteds[3]));	
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ')');
+		
+        //FormatString( 
+        //    sFormat := 'SIZE = [%d..%d,%d..%d,%d..%d] (%dx%dx%d)',
+        //    arg1 := F_DINT(LowerBoundActuals[1]),
+        //    arg2 := F_DINT(UpperBoundActuals[1]),
+        //    arg3 := F_DINT(LowerBoundActuals[2]),
+        //    arg4 := F_DINT(UpperBoundActuals[2]),
+        //    arg5 := F_DINT(LowerBoundActuals[3]),
+        //    arg6 := F_DINT(UpperBoundActuals[3]),
+        //    arg7 := F_DINT(SizeOfActuals[1]),
+        //    arg8 := F_DINT(SizeOfActuals[2]),
+        //    arg9 := F_DINT(SizeOfActuals[3]),
+        //    sOut => ActualString);
+		ActualString := 'SIZE = [';
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(LowerBoundActuals[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '..');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(UpperBoundActuals[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ',');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(LowerBoundActuals[2]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '..');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(UpperBoundActuals[2]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ',');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(LowerBoundActuals[3]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '..');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(UpperBoundActuals[3]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '] (');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(SizeOfActuals[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := 'x');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(SizeOfActuals[2]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := 'x');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(SizeOfActuals[3]));	
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ')');		
     ELSE
-        ExpectedValueString := REAL_TO_STRING(Expected);
-        ActualValueString := REAL_TO_STRING(Actual);
-        FormatString( 
-            sFormat := 'ARRAY[%d,%d,%d] = %s',
-            arg1 := F_DINT(ExpectedArrayIndex[1]),
-            arg2 := F_DINT(ExpectedArrayIndex[2]),
-            arg3 := F_DINT(ExpectedArrayIndex[3]),
-            arg4 := F_STRING(ExpectedValueString),
-            sOut => ExpectedString);
+        //ExpectedValueString := REAL_TO_STRING(Expected);
+        //ActualValueString := REAL_TO_STRING(Actual);
+        //FormatString( 
+        //    sFormat := 'ARRAY[%d,%d,%d] = %s',
+        //    arg1 := F_DINT(ExpectedArrayIndex[1]),
+        //    arg2 := F_DINT(ExpectedArrayIndex[2]),
+        //    arg3 := F_DINT(ExpectedArrayIndex[3]),
+        //    arg4 := F_STRING(ExpectedValueString),
+        //    sOut => ExpectedString);
+		ExpectedString := 'ARRAY[';
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(ExpectedArrayIndex[1]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ',');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(ExpectedArrayIndex[2]));
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := ',');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := DINT_TO_STRING(ExpectedArrayIndex[3]));		
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := '] = ');
+		ExpectedString := CONCAT(STR1 := ExpectedString, STR2 := REAL_TO_STRING(Expected) );			
 
-        FormatString( 
-            sFormat := 'ARRAY[%d,%d,%d] = %s',
-            arg1 := F_DINT(ActualArrayIndex[1]),
-            arg2 := F_DINT(ActualArrayIndex[2]),
-            arg3 := F_DINT(ActualArrayIndex[3]),
-            arg4 := F_STRING(ActualValueString),
-            sOut => ActualString);
+        //FormatString( 
+        //    sFormat := 'ARRAY[%d,%d,%d] = %s',
+        //    arg1 := F_DINT(ActualArrayIndex[1]),
+        //    arg2 := F_DINT(ActualArrayIndex[2]),
+        //    arg3 := F_DINT(ActualArrayIndex[3]),
+        //    arg4 := F_STRING(ActualValueString),
+        //    sOut => ActualString);
+		ActualString := 'ARRAY[';
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(ActualArrayIndex[1]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ',');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(ActualArrayIndex[2]));
+		ActualString := CONCAT(STR1 := ActualString, STR2 := ',');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := DINT_TO_STRING(ActualArrayIndex[3]));	
+		ActualString := CONCAT(STR1 := ActualString, STR2 := '] = ');
+		ActualString := CONCAT(STR1 := ActualString, STR2 := REAL_TO_STRING(Actual));
     END_IF
 
     AssertMessageFormatter.LogAssertFailure(Expected := ExpectedString,
@@ -3526,48 +3700,86 @@ END_IF]]></ST>
       <LineId Id="1208" Count="47" />
       <LineId Id="1353" Count="0" />
       <LineId Id="1257" Count="31" />
+      <LineId Id="1420" Count="0" />
+      <LineId Id="1422" Count="10" />
+      <LineId Id="1421" Count="0" />
       <LineId Id="1290" Count="9" />
+      <LineId Id="1434" Count="11" />
+      <LineId Id="1433" Count="0" />
       <LineId Id="1301" Count="0" />
-      <LineId Id="1388" Count="0" />
-      <LineId Id="1387" Count="0" />
-      <LineId Id="1302" Count="3" />
+      <LineId Id="1446" Count="0" />
+      <LineId Id="1303" Count="2" />
       <LineId Id="1383" Count="0" />
       <LineId Id="1307" Count="0" />
-      <LineId Id="1309" Count="1" />
+      <LineId Id="1449" Count="3" />
+      <LineId Id="1455" Count="0" />
+      <LineId Id="1448" Count="0" />
+      <LineId Id="1447" Count="0" />
+      <LineId Id="1310" Count="0" />
       <LineId Id="1352" Count="0" />
       <LineId Id="1312" Count="1" />
       <LineId Id="1384" Count="0" />
       <LineId Id="1315" Count="0" />
+      <LineId Id="1458" Count="4" />
+      <LineId Id="1457" Count="0" />
       <LineId Id="1317" Count="5" />
       <LineId Id="5" Count="0" />
     </LineIds>
     <LineIds Name="FB_TestSuite.AssertArray2dEquals_REAL">
       <LineId Id="1208" Count="80" />
+      <LineId Id="1389" Count="11" />
+      <LineId Id="1388" Count="0" />
       <LineId Id="1290" Count="9" />
+      <LineId Id="1402" Count="11" />
+      <LineId Id="1401" Count="0" />
+      <LineId Id="1387" Count="0" />
       <LineId Id="1301" Count="0" />
       <LineId Id="1354" Count="1" />
       <LineId Id="1302" Count="5" />
+      <LineId Id="1415" Count="4" />
+      <LineId Id="1414" Count="0" />
       <LineId Id="1309" Count="6" />
+      <LineId Id="1421" Count="4" />
+      <LineId Id="1420" Count="0" />
       <LineId Id="1317" Count="5" />
       <LineId Id="5" Count="0" />
     </LineIds>
     <LineIds Name="FB_TestSuite.AssertArray3dEquals_LREAL">
       <LineId Id="1138" Count="94" />
+      <LineId Id="1338" Count="17" />
+      <LineId Id="1337" Count="0" />
       <LineId Id="1234" Count="12" />
+      <LineId Id="1357" Count="17" />
+      <LineId Id="1356" Count="0" />
       <LineId Id="1248" Count="0" />
       <LineId Id="1303" Count="1" />
       <LineId Id="1249" Count="6" />
+      <LineId Id="1376" Count="6" />
+      <LineId Id="1375" Count="0" />
       <LineId Id="1257" Count="7" />
+      <LineId Id="1385" Count="3" />
+      <LineId Id="1391" Count="0" />
+      <LineId Id="1390" Count="0" />
+      <LineId Id="1389" Count="0" />
+      <LineId Id="1384" Count="0" />
       <LineId Id="1266" Count="5" />
       <LineId Id="5" Count="0" />
     </LineIds>
     <LineIds Name="FB_TestSuite.AssertArray3dEquals_REAL">
       <LineId Id="1167" Count="94" />
+      <LineId Id="1402" Count="17" />
+      <LineId Id="1401" Count="0" />
       <LineId Id="1263" Count="12" />
+      <LineId Id="1383" Count="17" />
+      <LineId Id="1382" Count="0" />
       <LineId Id="1277" Count="0" />
       <LineId Id="1332" Count="1" />
       <LineId Id="1278" Count="6" />
+      <LineId Id="1374" Count="6" />
+      <LineId Id="1373" Count="0" />
       <LineId Id="1286" Count="7" />
+      <LineId Id="1366" Count="6" />
+      <LineId Id="1365" Count="0" />
       <LineId Id="1295" Count="5" />
       <LineId Id="5" Count="0" />
     </LineIds>

--- a/TcUnit/TcUnit/POUs/FB_TestSuite.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_TestSuite.TcPOU
@@ -124,6 +124,8 @@ AddTestNameToInstancePath := Tc2_Utilities.CONCAT(STR1 := CompleteTestInstancePa
       <Declaration><![CDATA[METHOD PUBLIC AllTestsFinished : BOOL
 VAR
     Counter : UINT;
+
+    GetCurTaskIndex : Tc2_System.GETCURTASKINDEX;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[AllTestsFinished := FALSE;
@@ -133,6 +135,13 @@ IF NumberOfTests > 0 THEN
     FOR Counter := 1 TO GetAmountOfTests() BY 1 DO
         AllTestsFinished := AllTestsFinished AND Tests[Counter].IsFinished();
     END_FOR
+END_IF
+
+(* If we have been running at least one cycle and no tests are registered it means that this testsuite is empty
+   and doesn't contain any test cases. In that case, add a warning message and ignore this testsuite. *)
+GetCurTaskIndex();
+IF NumberOfTests = 0 AND NOT TwinCAT_SystemInfoVarList._TaskInfo[GetCurTaskIndex.index].FirstCycle THEN
+    AllTestsFinished := TRUE;
 END_IF]]></ST>
       </Implementation>
     </Method>
@@ -3506,6 +3515,12 @@ END_IF]]></ST>
       <LineId Id="6" Count="1" />
       <LineId Id="10" Count="0" />
       <LineId Id="4" Count="0" />
+      <LineId Id="38" Count="0" />
+      <LineId Id="35" Count="0" />
+      <LineId Id="40" Count="0" />
+      <LineId Id="46" Count="0" />
+      <LineId Id="34" Count="0" />
+      <LineId Id="36" Count="1" />
     </LineIds>
     <LineIds Name="FB_TestSuite.AssertArray2dEquals_LREAL">
       <LineId Id="1208" Count="47" />

--- a/TcUnit/TcUnit/POUs/FB_XmlControl.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_XmlControl.TcPOU
@@ -1,0 +1,370 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_XmlControl" Id="{f48b7de2-5c07-4763-a8be-3d8ab3c1f58c}" SpecialFunc="None">
+    <Declaration><![CDATA[(*
+Organizes parsing and composing of XML data. Data can be treated as STRING or Char Array.
+Filebuffersize is default 4096 Byte and can be set via Gvl_Param_XmlControl
+
+Usage example:
+
+	VAR
+		XML : XML_Control;
+		Buffer: STRING(GVL_Param_XmlControl.udiMaxFileSize);
+		//or
+		Buffer: ARRAY [0..GVL_Param_XmlControl.udiMaxFileSize] OF CHAR;
+	END_VAR
+
+	XML.pBuffer: = ADR (buffer);
+	XML.LenBuffer: = SIZEOF (buffer);
+
+	
+- Add your own preffered fileheader like:
+XML: <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+
+	XML.writeDocumentHeader( '<?xml version=\"1.0\" encoding=\"UTF-8\"?>');
+
+
+- Composing a tag with a parameters:
+XML: <MyTag ParaName = "11" />
+
+	XML.newTag(sTagName: = 'MyTag');
+	XML.newPara(sName: = 'ParaName', sPara: = sValue);
+	XML.CloseTag();
+
+
+- Tag value:
+XML: <MyTag> MyText </ MyTag>
+
+	XML.newTag(sName := 'MyTag');
+	XML.newTagData(sTagData :='MyText');
+	XML.CloseTag();
+
+	
+- Jump to the beginning of the XML data
+XML.toStartBuffer();
+
+
+- returns the next Tag from the current position in buffer
+XML.NextTag();
+
+
+- Output the parameter of the Tag
+XML.nextPara(sPara: = LastValue);
+Feedback: sPara returns the value found (string)
+
+
+*)
+{attribute 'hide_all_locals'}
+FUNCTION_BLOCK FB_XmlControl IMPLEMENTS I_XmlControl
+VAR
+	Buffer : FB_strBuffer;
+	TagList : FB_strBuffer;
+	sTags : STRING; 
+	TagListSeek : FB_strBuffer;
+	sTagsSeek : STRING; 
+	Tag : FB_strBuffer;
+	sTag : STRING;
+	xTagOpen: BOOL;
+	iSelect : UDINT;
+	iSelectStart : UDINT;
+	iSelectEnd : UDINT;
+	iSelectStartPara : UDINT;
+	iSelectEndPara : UDINT;
+	iSelectTagClose : UDINT;
+	iSelectStartValue : UDINT;
+	iSelectEndValue : UDINT;
+	udiSearchPos : UDINT; 
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[]]></ST>
+    </Implementation>
+    <Method Name="ClearBuffer" Id="{651b4460-232e-47e8-95ba-ecea1541fbb9}">
+      <Declaration><![CDATA[(* 
+	Clears the contents of the entire buffer
+*)
+METHOD ClearBuffer : Bool
+VAR_INPUT
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[udiSearchPos := 0;
+TagListSeek.Lenght := 0;
+Buffer.Lenght := 0;
+sTagsSeek := '';
+sTag := '';
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="closeTag" Id="{eedd2aac-2425-4325-8128-bfe1e984f3f7}">
+      <Declaration><![CDATA[(*
+	Close a Tag:
+	XML: <MyTag />
+
+	method: XML.CloseTag();
+*)
+METHOD closeTag : STRING
+VAR_INPUT
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[IF xTagOpen THEN
+	Buffer.Append := GVL_XmlControl.sEndTagClose;
+	iSelect := TagList.FindBack(sSearchString := GVL_XmlControl.sForwardSlash);
+	closeTag := TagList.CutOff(udiStartPos:= iSelect);
+	xTagOpen := FALSE;
+ELSE
+	iSelect := TagList.FindBack(sSearchString := GVL_XmlControl.sForwardSlash);
+	closeTag := TagList.CutOff(udiStartPos:= iSelect);
+	Buffer.Append := GVL_XmlControl.sTagOpen;
+	Buffer.Append := closeTag;
+	Buffer.Append := GVL_XmlControl.sTagClose;
+END_IF;
+]]></ST>
+      </Implementation>
+    </Method>
+    <Property Name="Lenght" Id="{4fdf30b6-5fe7-4452-ad0a-85e866e236d0}">
+      <Declaration><![CDATA[PROPERTY Lenght : UDINT
+]]></Declaration>
+      <Get Name="Get" Id="{267105d4-b124-4c5c-a359-0434c4992afc}">
+        <Declaration><![CDATA[VAR
+END_VAR
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[Lenght := Buffer.Lenght;]]></ST>
+        </Implementation>
+      </Get>
+    </Property>
+    <Method Name="newComment" Id="{0f41fa45-b92e-4e7e-b2b3-ecb5d5918326}">
+      <Declaration><![CDATA[METHOD newComment : BOOL
+VAR_INPUT
+	sCommand : STRING;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[(* Ist noch ein TAG offen dann erst Schließen *)
+IF xTagOpen THEN
+	Buffer.Append := GVL_XmlControl.sTagClose;
+	xTagOpen := FALSE;
+END_IF;
+Buffer.Append := sCommand;
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="newPara" Id="{60c10606-ff09-4f9b-a3dd-0b54d0f565c7}">
+      <Declaration><![CDATA[(*
+	Should be called after opening a new tag
+	
+	XML.newPara(sName: = 'ParaName', sPara: = sValue);
+*)
+METHOD newPara : BOOL
+VAR_INPUT
+	sParaName : STRING;
+	sValue : STRING;	
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[// sParaName="sValue"
+Buffer.Append := GVL_XmlControl.sSpace;  
+Buffer.Append := sParaName;
+Buffer.Append := GVL_XmlControl.sEQ; 
+Buffer.Append := GVL_XmlControl.sQuote; 
+Buffer.Append := sValue;
+Buffer.Append := GVL_XmlControl.sQuote;]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="newTag" Id="{c44bdbda-725a-4943-a5cc-fa5ea9485541}">
+      <Declaration><![CDATA[(*
+	Creates a new Tag:
+	XML: <MyTag>
+	
+	XML.newTag(sTagName: = 'MyTag');
+*)
+METHOD newTag : BOOL
+VAR_INPUT
+	sTagName : STRING;
+END_VAR]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[IF xTagOpen THEN
+	Buffer.Append := GVL_XmlControl.sTagClose; // >
+END_IF;
+Buffer.Append := GVL_XmlControl.sTagOpen; // <
+Buffer.Append := sTagName;
+xTagOpen := TRUE;
+TagList.Append := GVL_XmlControl.sForwardSlash; 
+TagList.Append := sTagName;
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="newTagData" Id="{e4679d3f-10eb-47fd-936c-97e3aaaa3768}">
+      <Declaration><![CDATA[METHOD newTagData : BOOL
+VAR_INPUT
+	sTagData : STRING;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[Buffer.Append := GVL_XmlControl.sTagClose;
+Buffer.Append := sTagData;
+xTagOpen := FALSE;
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="NextPara" Id="{4394d0a2-f7bc-4847-9625-00022c462a79}">
+      <Declaration><![CDATA[METHOD NextPara : STRING;
+VAR_OUTPUT
+	sPara : STRING;	
+END_VAR
+VAR
+	sName : STRING;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[iSelectEndPara := Buffer.Find(sSearchString := GVL_XmlControl.sEQ, udiStartPos := iSelectStartPara);
+IF iSelectStartPara < iSelectEnd AND iSelectEndPara < iSelectEnd THEN
+	sName := Buffer.Copy( udiStart := iSelectStartPara + 1, udiEnd := iSelectEndPara);
+	iSelectStartValue := Buffer.Find(sSearchString := GVL_XmlControl.sQuote, udiStartPos := iSelectEndPara);
+	iSelectEndValue := Buffer.Find(sSearchString := GVL_XmlControl.sQuote, udiStartPos := iSelectStartValue);
+	sPara := Buffer.Copy( udiStart := iSelectStartValue + 1, udiEnd := iSelectEndValue);
+	iSelectStartPara := iSelectEndValue + 1;
+ELSE 
+	iSelectEndValue := Buffer.Find(sSearchString := GVL_XmlControl.sTagOpen, udiStartPos := udiSearchPos);
+	sName := Buffer.Copy( udiStart := udiSearchPos + 1, udiEnd := iSelectEndValue); 
+END_IF;
+NextPara := sName;
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="NextTag" Id="{d039b781-905d-4b69-b5aa-bb0323e598de}">
+      <Declaration><![CDATA[METHOD NextTag : STRING
+VAR_INPUT
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[iSelectStart := Buffer.Find(sSearchString := GVL_XmlControl.sTagOpen, udiStartPos := udiSearchPos);
+iSelectEnd := Buffer.Find(sSearchString := GVL_XmlControl.sTagClose, udiStartPos := iSelectStart);
+iSelectStartPara := Buffer.Find(sSearchString := GVL_XmlControl.sSpace, udiStartPos := iSelectStart);
+iSelectTagClose := Buffer.Find(sSearchString := GVL_XmlControl.sForwardSlash, udiStartPos := iSelectStart);
+IF iSelectStart < Buffer.Lenght AND iSelectEnd < Buffer.Lenght THEN
+	udiSearchPos := iSelectEnd;
+	sTag := Buffer.Copy( udiStart:= iSelectStart + 1, udiEnd:= iSelectEnd);
+	IF iSelectEnd < iSelectStartPara THEN
+		NextTag := Buffer.Copy( udiStart:= iSelectStart + 1, udiEnd:= iSelectEnd);
+	ELSE
+		NextTag := Buffer.Copy( udiStart:= iSelectStart + 1, udiEnd:= iSelectStartPara);
+	END_IF;
+	IF iSelectTagClose = iSelectStart +1 THEN
+		iSelect := TagListSeek.FindBack(sSearchString := GVL_XmlControl.sForwardSlash);
+		TagListSeek.CutOff(udiStartPos:= iSelect);
+	ELSIF iSelectTagClose > iSelectStart AND iSelectTagClose < iSelectEnd THEN
+		TagListSeek.Append := '/';
+		TagListSeek.Append := NextTag;
+		iSelect := TagListSeek.FindBack(sSearchString := GVL_XmlControl.sForwardSlash);
+		TagListSeek.CutOff(udiStartPos:= iSelect);
+	ELSE
+		TagListSeek.Append := GVL_XmlControl.sForwardSlash;
+		TagListSeek.Append := NextTag;
+	END_IF;
+ELSE
+	udiSearchPos := Buffer.Lenght;
+	NextTag := '';
+END_IF;]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="SetBuffer" Id="{cbfaa6d5-eab9-48d0-a339-a8bf334e344e}">
+      <Declaration><![CDATA[METHOD SetBuffer : BOOL
+VAR_INPUT
+	pString : POINTER TO BYTE;
+	iSizeOf : UDINT;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[Buffer.Set(pbyAdr := pString, udiSize := iSizeOf);
+TagList.Set(pbyAdr := ADR(sTags), udiSize := SIZEOF(sTags));
+TagListSeek.Set(pbyAdr := ADR(sTagsSeek), udiSize := SIZEOF(sTagsSeek));
+Tag.Set(pbyAdr := ADR(sTag), udiSize := SIZEOF(sTag));]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="ToStartBuffer" Id="{cb065068-a6c8-48d5-8c1d-535a21365348}">
+      <Declaration><![CDATA[(*
+- Jump to the beginning of the XML data
+	XML.toStartBuffer();
+*)
+METHOD ToStartBuffer
+VAR_INPUT
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[udiSearchPos := 0;
+TagListSeek.Lenght := 0;
+sTagsSeek := '';
+sTag := '';
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="writeDocumentHeader" Id="{14bf2549-9e7d-451f-8ab5-fe662eb30712}">
+      <Declaration><![CDATA[(*
+- Add your own preffered fileheader like:
+XML: <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+
+	XML.writeDocumentHeader( '<?xml version=\"1.0\" encoding=\"UTF-8\"?>');
+
+*)
+METHOD writeDocumentHeader
+VAR_INPUT
+	strHeader	: STRING;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[buffer.append := strHeader;]]></ST>
+      </Implementation>
+    </Method>
+    <LineIds Name="FB_XmlControl">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_XmlControl.ClearBuffer">
+      <LineId Id="3" Count="4" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_XmlControl.closeTag">
+      <LineId Id="3" Count="11" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_XmlControl.Lenght.Get">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_XmlControl.newComment">
+      <LineId Id="3" Count="5" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_XmlControl.newPara">
+      <LineId Id="3" Count="5" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_XmlControl.newTag">
+      <LineId Id="3" Count="7" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_XmlControl.newTagData">
+      <LineId Id="3" Count="2" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_XmlControl.NextPara">
+      <LineId Id="3" Count="11" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_XmlControl.NextTag">
+      <LineId Id="3" Count="26" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_XmlControl.SetBuffer">
+      <LineId Id="3" Count="2" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_XmlControl.ToStartBuffer">
+      <LineId Id="3" Count="3" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_XmlControl.writeDocumentHeader">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+  </POU>
+</TcPlcObject>

--- a/TcUnit/TcUnit/POUs/FB_XmlControl.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_XmlControl.TcPOU
@@ -44,6 +44,12 @@ XML: <MyTag> MyText </ MyTag>
 XML.toStartBuffer();
 
 
+- Adds a comment:
+XML: <!-- MyComment -->
+	
+	XML.newComment(sTagName: = 'MyComment');
+
+
 - returns the next Tag from the current position in buffer
 XML.NextTag();
 
@@ -51,7 +57,6 @@ XML.NextTag();
 - Output the parameter of the Tag
 XML.nextPara(sPara: = LastValue);
 Feedback: sPara returns the value found (string)
-
 
 *)
 {attribute 'hide_all_locals'}
@@ -135,18 +140,29 @@ END_VAR
       </Get>
     </Property>
     <Method Name="newComment" Id="{0f41fa45-b92e-4e7e-b2b3-ecb5d5918326}">
-      <Declaration><![CDATA[METHOD newComment : BOOL
+      <Declaration><![CDATA[(*
+	Adds a comment;
+	XML: <!-- MyComment -->
+	
+	XML.newComment(sTagName: = 'MyComment');
+*)
+METHOD newComment : BOOL
 VAR_INPUT
-	sCommand : STRING;
+	sComment : STRING;
+END_VAR
+VAR
+
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[(* Ist noch ein TAG offen dann erst Schließen *)
-IF xTagOpen THEN
+        <ST><![CDATA[IF xTagOpen THEN
 	Buffer.Append := GVL_XmlControl.sTagClose;
 	xTagOpen := FALSE;
 END_IF;
-Buffer.Append := sCommand;
+Buffer.Append := GVL_XmlControl.sOpenComment; // <!-- 
+Buffer.Append := sComment;
+Buffer.Append := GVL_XmlControl.sCloseComment; // -->
+
 ]]></ST>
       </Implementation>
     </Method>
@@ -163,7 +179,7 @@ VAR_INPUT
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[// sParaName="sValue"
+        <ST><![CDATA[
 Buffer.Append := GVL_XmlControl.sSpace;  
 Buffer.Append := sParaName;
 Buffer.Append := GVL_XmlControl.sEQ; 
@@ -332,7 +348,11 @@ END_VAR
       <LineId Id="2" Count="0" />
     </LineIds>
     <LineIds Name="FB_XmlControl.newComment">
-      <LineId Id="3" Count="5" />
+      <LineId Id="4" Count="3" />
+      <LineId Id="16" Count="0" />
+      <LineId Id="8" Count="0" />
+      <LineId Id="22" Count="0" />
+      <LineId Id="21" Count="0" />
       <LineId Id="2" Count="0" />
     </LineIds>
     <LineIds Name="FB_XmlControl.newPara">

--- a/TcUnit/TcUnit/POUs/FB_strBuffer.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_strBuffer.TcPOU
@@ -1,0 +1,302 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_strBuffer" Id="{e52f4441-8a0a-4101-967b-b7eab2a848a9}" SpecialFunc="None">
+    <Declaration><![CDATA[(*
+	This functionblock acts as an IO stream buffer for use with FB_XmlControl
+*)
+{attribute 'hide_all_locals'}
+FUNCTION_BLOCK FB_strBuffer 
+VAR
+	pString : POINTER TO BYTE;
+	udiLenght : UDINT;
+	udiSizeOf : UDINT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[]]></ST>
+    </Implementation>
+    <Property Name="Append" Id="{1420d8a5-f130-452c-8825-a3f354a987ec}">
+      <Declaration><![CDATA[// appends a string to the buffer
+PROPERTY Append : STRING]]></Declaration>
+      <Set Name="Set" Id="{0b19b506-e9b9-4278-a6d8-4293484e7c2a}">
+        <Declaration><![CDATA[VAR
+	pByteIn : POINTER TO BYTE;
+	pByteBuffer : POINTER TO BYTE;
+END_VAR
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[pByteIn := ADR(Append); 
+pByteBuffer := pString + udiLenght;
+WHILE pByteIn^ <> 0 AND(udiLenght < udiSizeOf ) DO
+	pByteBuffer^ := pByteIn^;
+	udiLenght := udiLenght + 1;
+	pByteIn := pByteIn + 1;
+	pByteBuffer := pByteBuffer + 1;
+END_WHILE;
+
+pByteBuffer := pString + udiLenght; (* String End *)
+pByteBuffer^ := 0;
+
+]]></ST>
+        </Implementation>
+      </Set>
+    </Property>
+    <Property Name="BufferSize" Id="{68afd1a2-de65-4e12-b73f-fea349e03e95}">
+      <Declaration><![CDATA[// Read Current Buffersize
+PROPERTY BufferSize : UDINT
+]]></Declaration>
+      <Get Name="Get" Id="{50c00d93-002d-4d51-b127-116588bc6b70}">
+        <Declaration><![CDATA[VAR
+END_VAR
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[BufferSize := udiSizeOf;]]></ST>
+        </Implementation>
+      </Get>
+    </Property>
+    <Method Name="Copy" Id="{2c390f42-4281-4b36-9491-cb075b58b84f}">
+      <Declaration><![CDATA[(*
+	Copies a string from the character buffer
+*)	
+METHOD Copy : STRING
+VAR_INPUT
+	udiStart : UDINT;
+	udiEnd : UDINT;
+END_VAR
+VAR_OUTPUT
+	udiCopyLen : UDINT;
+	eXmlError : eXML;
+END_VAR
+VAR
+	udiLoop : UDINT;
+	pByteCopy : POINTER TO BYTE;
+	pByteBuffer : POINTER TO BYTE;
+END_VAR
+
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[udiLoop := 0;
+pByteCopy := ADR(Copy);
+pByteBuffer := pString + udiStart - 1;
+
+WHILE(udiLoop < SIZEOF(Copy)) AND udiStart - 1 + udiLoop < udiLenght AND udiStart + udiLoop < udiEnd DO
+	pByteCopy^ := pByteBuffer^;
+	udiLoop := udiLoop + 1;
+	pByteCopy := ADR(Copy) + udiLoop;
+	pByteBuffer := pString + udiStart + udiLoop -1;
+END_WHILE;
+
+IF udiLoop = SIZEOF(Copy) THEN
+	eXmlError := eXML.errStringLen;
+ELSIF udiStart - 1 + udiLoop = udiLenght THEN
+	eXmlError := eXML.errMaxBufferLen;
+ELSE
+	eXmlError := eXML.OK;
+END_IF;
+
+pByteCopy^ := 0;
+udiCopyLen :=  udiLoop;]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="CutOff" Id="{c6a3de4e-6324-4b78-aaa1-8f0f469c3e8a}">
+      <Declaration><![CDATA[METHOD CutOff : STRING
+VAR_INPUT
+	udiStartPos : UDINT;
+END_VAR
+VAR_OUTPUT
+	udiCutLen : UDINT; 
+	eXmlError : eXML;
+END_VAR
+VAR
+	iLoop : UDINT;
+	pByteCut : POINTER TO BYTE;
+	pByteBuffer : POINTER TO BYTE;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[iLoop := 0;
+pByteCut := ADR(CutOff);
+pByteBuffer := pString + udiStartPos - 1;
+
+WHILE pByteBuffer^ <> 0 AND(iLoop < SIZEOF(CutOff)) AND udiStartPos -1  + iLoop < udiLenght DO
+	pByteCut^ := pByteBuffer^;
+	iLoop := iLoop + 1;
+	pByteCut := ADR(CutOff) + iLoop;
+	pByteBuffer := pString + udiStartPos - 1 + iLoop;
+END_WHILE;
+
+IF pByteBuffer^ = 0 THEN
+	eXmlError := eXML.OK;
+ELSIF iLoop = SIZEOF(CutOff) THEN
+	eXmlError := eXML.errStringLen;
+ELSIF udiStartPos -1 + iLoop = udiLenght THEN
+	eXmlError := eXML.errMaxBufferLen;
+END_IF;
+
+pByteCut^ := 0;
+udiLenght := udiStartPos -1;
+
+pByteBuffer := pString + udiStartPos - 1;
+pByteBuffer^ := 0;
+
+udiCutLen := iLoop;
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="Find" Id="{005c59da-78f6-44f5-992f-5ed00155aa65}">
+      <Declaration><![CDATA[(* 
+	Find a searchstring in the buffer and returns its position.
+	It's possible to add a preffered startposition within buffer
+*)
+METHOD Find : UDINT
+VAR_INPUT
+	sSearchString : STRING;
+	udiStartPos : UDINT;
+END_VAR
+VAR
+	udiLoop : UDINT;
+	iSearch : UDINT;
+	pBuffer : POINTER TO BYTE;
+	pSearch : POINTER TO BYTE;
+END_VAR
+
+
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[udiLoop := 0;
+iSearch := 0;
+
+pBuffer := pString + udiStartPos;
+pSearch := ADR( sSearchString);
+
+WHILE(pSearch^ <> 0 ) AND udiLoop + udiStartPos < udiLenght DO
+	IF pBuffer^ <> pSearch^ THEN
+		udiLoop := udiLoop + 1;
+		pBuffer := pString + udiStartPos + udiLoop;
+		pSearch := ADR( sSearchString);
+		iSearch := 0;
+	ELSE
+		iSearch := iSearch +1;
+		pBuffer := pString + udiStartPos + udiLoop + iSearch;
+		pSearch := ADR( sSearchString ) + iSearch;
+	END_IF;
+END_WHILE;
+Find := udiLoop + 1 + udiStartPos;
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="FindBack" Id="{9839d1e8-50a3-46d6-bcc3-683d35336c78}">
+      <Declaration><![CDATA[METHOD FindBack : UDINT
+VAR_INPUT
+	sSearchString : STRING;
+END_VAR
+VAR
+	udiLoop : UDINT;
+	udiSearch : UDINT;
+	pBuffer : POINTER TO BYTE;
+	pSearch : POINTER TO BYTE;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[udiLoop := 0;
+udiSearch := 0;
+
+pBuffer := pString + udiLenght;
+pSearch := ADR( sSearchString);
+
+WHILE(pSearch^ <> 0 ) AND udiLoop < udiLenght DO
+	IF pBuffer^ <> pSearch^ THEN
+		udiLoop := udiLoop + 1;
+		pBuffer := pString + udiLenght - udiLoop;
+		pSearch := ADR( sSearchString);
+		udiSearch := 0;
+	ELSE
+		udiSearch := udiSearch +1;
+		pBuffer := pString + udiLenght - udiLoop + udiSearch;
+		pSearch := ADR( sSearchString ) + udiSearch;
+	END_IF;
+END_WHILE;
+FindBack :=  udiLenght - udiLoop + 1;]]></ST>
+      </Implementation>
+    </Method>
+    <Property Name="Lenght" Id="{4091adec-4bb4-4fd6-8526-9c7c148f5fb6}">
+      <Declaration><![CDATA[PROPERTY Lenght : UDINT
+]]></Declaration>
+      <Get Name="Get" Id="{68d61c18-5880-4fca-bc19-2627561e031b}">
+        <Declaration><![CDATA[VAR
+END_VAR
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[Lenght := udiLenght;]]></ST>
+        </Implementation>
+      </Get>
+      <Set Name="Set" Id="{771e0e96-6938-4002-9e95-f5464d90932a}">
+        <Declaration><![CDATA[
+VAR
+END_VAR
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[udiLenght := Lenght;]]></ST>
+        </Implementation>
+      </Set>
+    </Property>
+    <Method Name="Set" Id="{4febb494-7fac-41a4-adad-f24be4f91872}">
+      <Declaration><![CDATA[(* Sets the Buffer *)
+METHOD Set : BOOL;
+VAR_INPUT
+	// set buffer adress (ADR ...)
+	pbyAdr : POINTER TO BYTE;
+	// set buffer size (SIZEOF ...)
+	udiSize : UDINT;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[IF (pbyAdr = 0)OR (udiSize = 0) THEN
+	Set := FALSE;
+	RETURN;
+END_IF;
+
+udiSizeOf := udiSize;
+pString := pbyAdr;
+
+Set := TRUE;]]></ST>
+      </Implementation>
+    </Method>
+    <LineIds Name="FB_strBuffer">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_strBuffer.Append.Set">
+      <LineId Id="3" Count="11" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_strBuffer.BufferSize.Get">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_strBuffer.Copy">
+      <LineId Id="3" Count="19" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_strBuffer.CutOff">
+      <LineId Id="3" Count="25" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_strBuffer.Find">
+      <LineId Id="3" Count="18" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_strBuffer.FindBack">
+      <LineId Id="3" Count="17" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_strBuffer.Lenght.Get">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_strBuffer.Lenght.Set">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_strBuffer.Set">
+      <LineId Id="3" Count="7" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+  </POU>
+</TcPlcObject>

--- a/TcUnit/TcUnit/TcUnit.plcproj
+++ b/TcUnit/TcUnit/TcUnit.plcproj
@@ -41,11 +41,15 @@ Documentation and examples are available at www.tcunit.org</Description>
     <Folder Include="ITFs" />
     <Folder Include="DUTs" />
     <Folder Include="GVLs" />
+    <Folder Include="Xml Integration Test" />
     <Folder Include="POUs" />
     <Folder Include="POUs\Functions" />
     <Folder Include="Version" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DUTs\eXML.TcDUT">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="DUTs\ST_ADSLogStringMessage.TcDUT">
       <SubType>Code</SubType>
     </Compile>
@@ -68,14 +72,35 @@ Documentation and examples are available at www.tcunit.org</Description>
       <SubType>Code</SubType>
       <LinkAlways>true</LinkAlways>
     </Compile>
+    <Compile Include="GVLs\GVL_Param_XmlControl.TcGVL">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="GVLs\GVL_TcUnit.TcGVL">
       <SubType>Code</SubType>
       <LinkAlways>true</LinkAlways>
+    </Compile>
+    <Compile Include="GVLs\GVL_XmlControl.TcGVL">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="ITFs\I_FileControl.TcIO">
+      <SubType>Code</SubType>
     </Compile>
     <Compile Include="ITFs\I_AssertMessageFormatter.TcIO">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="ITFs\I_TestResultFormatter.TcIO">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="ITFs\I_XmlControl.TcIO">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\FB_strBuffer.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\FB_XmlControl.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\FB_FileControl.TcPOU">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\FB_AdjustAssertFailureMessageToMax252CharLength.TcPOU">
@@ -132,8 +157,15 @@ Documentation and examples are available at www.tcunit.org</Description>
     <Compile Include="Version\Global_Version.TcGVL">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Xml Integration Test\XmlIntegrationTest.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
+    <PlaceholderReference Include="SysFile">
+      <DefaultResolution>SysFile, * (System)</DefaultResolution>
+      <Namespace>SysFile</Namespace>
+    </PlaceholderReference>
     <PlaceholderReference Include="Tc2_Standard">
       <DefaultResolution>Tc2_Standard, * (Beckhoff Automation GmbH)</DefaultResolution>
       <Namespace>Tc2_Standard</Namespace>

--- a/TcUnit/TcUnit/Xml Integration Test/XmlIntegrationTest.TcPOU
+++ b/TcUnit/TcUnit/Xml Integration Test/XmlIntegrationTest.TcPOU
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="XmlIntegrationTest" Id="{917c49f4-3643-42fe-b791-ac2edc0df35b}" SpecialFunc="None">
+    <Declaration><![CDATA[PROGRAM XmlIntegrationTest
+VAR
+	FileControl : FB_FileControl;
+	stFileAccessMode : SysFile.ACCESS_MODE := SysFile.AM_WRITE_PLUS;
+	szFilename : STRING := 'C:/XmlControl/output.xml';
+	
+	XmlControl : FB_XmlControl;
+	//Buffer : ARRAY [0..GVL_Param_XmlControl.udiMaxFileSize] OF BYTE;
+	Buffer : STRING(GVL_Param_XmlControl.udiMaxFileSize);
+		
+	xInit: BOOL := TRUE;	
+	xCreate : BOOL := FALSE;
+	xWrite : BOOL := FALSE;
+	
+	sTag : STRING; 
+	sPara : STRING;
+	sTagPara : STRING;
+	
+	xRead : BOOL := FALSE;
+	iStateRead : DINT := 0; 
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF xInit THEN
+	XmlControl.SetBuffer(pString := ADR(Buffer), iSizeOf := SIZEOF(Buffer));
+	xInit := FALSE;
+END_IF
+
+IF xCreate THEN
+	// generate xml content 
+	//WriteTest1();
+	//WriteTest2();
+	//WriteTest3();
+	WriteTest4(); 
+	xCreate := FALSE;
+END_IF;
+IF xWrite THEN
+	// write it to a file
+	Write2File();
+	xWrite := FALSE;
+END_IF;
+IF xRead THEN
+	// Read a parameter by reading a file into the buffer
+	ParaRead();
+END_IF;]]></ST>
+    </Implementation>
+    <Action Name="ParaRead" Id="{05fe8df7-dd2a-4848-bed4-bb3fdc2f0857}">
+      <Implementation>
+        <ST><![CDATA[CASE iStateRead OF
+	0:
+		(* open file *)
+		FileControl.fileOpen(szFilename := szFilename, stFileAccessMode := stFileAccessMode);
+		iStateRead := 10;
+		
+	10:
+		(* read file into buffer *)
+		FileControl.fileRead(pString := ADR(Buffer),SIZEOF(Buffer));
+		(* close file *)
+		FileControl.fileClose();
+		iStateRead := 20;
+		
+	20:
+		(* the buffer is now filled in memory and the original file has been closed *)
+		sTag := XmlControl.NextTag();
+		IF XmlControl.udiSearchPos >= XmlControl.Lenght THEN
+			xRead := FALSE;	// Buffer is spent 
+		END_IF
+	
+	100:
+		(* File does not contain a 'user' tag anymore *) 
+ 		
+
+	
+END_CASE]]></ST>
+      </Implementation>
+    </Action>
+    <Action Name="write2File" Id="{578cc7fa-f2b0-4c18-a9a3-9c02fc7cd445}">
+      <Implementation>
+        <ST><![CDATA[// write the internal buffer to a file
+
+FileControl.fileOpen(szFilename := szFilename, stFileAccessMode := stFileAccessMode);
+FileControl.fileSave(pString := ADR(Buffer), SIZEOF(Buffer) );
+FileControl.fileClose();]]></ST>
+      </Implementation>
+    </Action>
+    <Action Name="WriteTest1" Id="{177eb003-1eb8-4f34-97de-f4440b580ef5}">
+      <Implementation>
+        <ST><![CDATA[XmlControl.writeDocumentHeader(strHeader := '<?xml version=\"1.0\" encoding=\"UTF-8\"?>');
+XmlControl.newTag('users');
+XmlControl.closeTag();
+	]]></ST>
+      </Implementation>
+    </Action>
+    <Action Name="WriteTest2" Id="{53abce43-9d6a-4309-9ccb-3043acc441b2}">
+      <Implementation>
+        <ST><![CDATA[XmlControl.writeDocumentHeader(strHeader := '<?xml version=\"1.0\" encoding=\"UTF-8\"?>');
+XmlControl.newTag('users');
+XmlControl.newTag('user');
+XmlControl.newPara('age', '42');
+XmlControl.newTagData('John Doe');
+XmlControl.closeTag();
+XmlControl.closeTag();]]></ST>
+      </Implementation>
+    </Action>
+    <Action Name="WriteTest3" Id="{24691e09-5c50-4787-9e26-972cfc6a1183}">
+      <Implementation>
+        <ST><![CDATA[XmlControl.writeDocumentHeader(strHeader := '<?xml version=\"1.0\" encoding=\"UTF-8\"?>');
+XmlControl.newTag('users');
+XmlControl.newTag('user');
+XmlControl.newPara('age', '42');
+XmlControl.newTagData('John Doe');
+XmlControl.closeTag();
+XmlControl.newTag('user');
+XmlControl.newPara('age', '39');
+XmlControl.newTagData('Jane Doe');
+XmlControl.closeTag();
+XmlControl .closeTag();]]></ST>
+      </Implementation>
+    </Action>
+    <Action Name="WriteTest4" Id="{0f364167-3776-40b3-a95a-439619939554}">
+      <Implementation>
+        <ST><![CDATA[XmlControl.writeDocumentHeader(strHeader := '<?xml version=\"1.0\" encoding=\"UTF-8\"?>');
+XmlControl.newTag('users');
+XmlControl.newTag('user');
+XmlControl.newPara('age', '42');
+XmlControl.newPara('sex', 'male');
+XmlControl.newTagData('John Doe');
+XmlControl.closeTag();
+XmlControl.newTag('user');
+XmlControl.newPara('age', '39');
+XmlControl.newPara('sex', 'female');
+XmlControl.newTagData('Jane Doe');
+XmlControl.closeTag();
+XmlControl.closeTag();]]></ST>
+      </Implementation>
+    </Action>
+    <LineIds Name="XmlIntegrationTest">
+      <LineId Id="3" Count="20" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="XmlIntegrationTest.ParaRead">
+      <LineId Id="2" Count="24" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="XmlIntegrationTest.write2File">
+      <LineId Id="2" Count="3" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="XmlIntegrationTest.WriteTest1">
+      <LineId Id="2" Count="2" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="XmlIntegrationTest.WriteTest2">
+      <LineId Id="2" Count="5" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="XmlIntegrationTest.WriteTest3">
+      <LineId Id="2" Count="9" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="XmlIntegrationTest.WriteTest4">
+      <LineId Id="2" Count="11" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+  </POU>
+</TcPlcObject>


### PR DESCRIPTION
FB_XmlControl.TcPOU,
FB_FileControl.TcPOU
plus several artefacts needed for them including an integration test which demonstrates the usage ( can be removed)

Removed FB_FormatString and used Concat to format messages in methods for;
array2d_real
array2d_lreal
array3d_real
array3d_lreal

TcVerifier shows the following result:
Error	123	3-8-2019 23:39:06 757 ms   | 'PlcTask' (350): | ==========TESTS FINISHED RUNNING==========
Error	124	3-8-2019 23:39:06 817 ms   | 'PlcTask' (350): | Test suites: 14
Error	125	3-8-2019 23:39:06 877 ms   | 'PlcTask' (350): | Tests: 183
Error	126	3-8-2019 23:39:06 937 ms   | 'PlcTask' (350): | Successful tests: 91
Error	127	3-8-2019 23:39:06 997 ms   | 'PlcTask' (350): | Failed tests: 92
Error	128	3-8-2019 23:39:07 057 ms   | 'PlcTask' (350): | ======================================