### PR TITLE
Skip assert statements if the test has finished running

### DIFF
--- a/TcUnit/TcUnit/GVLs/GVL_TcUnit.TcGVL
+++ b/TcUnit/TcUnit/GVLs/GVL_TcUnit.TcGVL
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.9">
   <GVL Name="GVL_TcUnit" Id="{78472b76-c9a4-4b27-a580-8e7898edc3d7}">
     <Declaration><![CDATA[{attribute 'no_assign'}
 {attribute 'qualified_only'}
@@ -14,6 +14,9 @@ VAR_GLOBAL
 
     (* Current name of test being called *)
     CurrentTestNameBeingCalled : Tc2_System.T_MaxString;
+
+    (* Whether or not the current test being called has finished running *)
+    CurrentTestIsFinished : BOOL;
 
     (* This is a flag that indicates that the current test should be ignored, and
        thus that all assertions under it should be ignored as well. A test can be ignored either

--- a/TcUnit/TcUnit/POUs/FB_TestSuite.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_TestSuite.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.9">
   <POU Name="FB_TestSuite" Id="{f80c23f2-119d-406b-ae11-06d1991bf64d}" SpecialFunc="None">
     <Declaration><![CDATA[(* This function block is responsible for holding the internal state of the test suite.
    Every test suite can have one or more tests, and every test can do one or more asserts.
@@ -176,7 +176,7 @@ VAR
     Actual : LREAL; // Single actual value
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -328,7 +328,7 @@ VAR
     Actual : REAL; // Single actual value
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -480,7 +480,7 @@ VAR
     Actual : LREAL; // Single actual value
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -662,7 +662,7 @@ VAR
     FormatString : Tc2_Utilities.FB_FormatString; // String formatter for output messages
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -836,7 +836,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -929,7 +929,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -1028,7 +1028,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -1121,7 +1121,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -1220,7 +1220,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -1311,7 +1311,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -1400,7 +1400,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -1493,7 +1493,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -1590,7 +1590,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -1681,7 +1681,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -1772,7 +1772,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -1863,7 +1863,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -1954,7 +1954,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2045,7 +2045,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2138,7 +2138,7 @@ VAR
     ActualsIndex : DINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2275,7 +2275,7 @@ VAR
     wordActual : WORD;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2525,7 +2525,7 @@ VAR
     TestInstancePath : Tc2_System.T_MaxString;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2564,7 +2564,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2611,7 +2611,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2650,7 +2650,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2689,7 +2689,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2728,7 +2728,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2775,7 +2775,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2814,7 +2814,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2854,7 +2854,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2893,7 +2893,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2932,7 +2932,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -2980,7 +2980,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -3019,7 +3019,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -3058,7 +3058,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -3097,7 +3097,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -3136,7 +3136,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -3175,7 +3175,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -3214,7 +3214,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -3253,7 +3253,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -3292,7 +3292,7 @@ VAR
     TestInstancePath : Tc2_System.T_MaxString;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -3331,7 +3331,7 @@ VAR
     AlreadyReported : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest THEN
+        <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
 END_IF
 
@@ -3443,6 +3443,27 @@ GetNumberOfFailedTests := FailedTestsCount;]]></ST>
       <Declaration><![CDATA[METHOD PUBLIC GetNumberOfTests : UINT]]></Declaration>
       <Implementation>
         <ST><![CDATA[GetNumberOfTests := NumberOfTests;]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="IsTestFinished" Id="{1ef139e2-1210-4139-ba5c-329f8493b09c}">
+      <Declaration><![CDATA[METHOD PUBLIC IsTestFinished : BOOL
+VAR_INPUT
+    TestName : Tc2_System.T_MaxString;
+END_VAR
+VAR
+    IteratorCounter : UINT;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[IsTestFinished := FALSE;
+IF NumberOfTests > 0 THEN
+    FOR IteratorCounter := 1 TO NumberOfTests BY 1 DO
+        IF Tests[IteratorCounter].GetName() = TestName THEN
+            IsTestFinished := Tests[IteratorCounter].IsFinished();
+            RETURN;
+        END_IF
+    END_FOR
+END_IF]]></ST>
       </Implementation>
     </Method>
     <Method Name="SetTestFailed" Id="{79b1664f-2570-4cef-bd6e-d7307d9a7818}">
@@ -4479,6 +4500,13 @@ END_IF]]></ST>
       <LineId Id="18" Count="0" />
     </LineIds>
     <LineIds Name="FB_TestSuite.GetNumberOfTests">
+      <LineId Id="5" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.IsTestFinished">
+      <LineId Id="20" Count="0" />
+      <LineId Id="6" Count="3" />
+      <LineId Id="11" Count="1" />
+      <LineId Id="14" Count="0" />
       <LineId Id="5" Count="0" />
     </LineIds>
     <LineIds Name="FB_TestSuite.SetTestFailed">

--- a/TcUnit/TcUnit/POUs/Functions/TEST.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/TEST.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.9">
   <POU Name="TEST" Id="{8dd61791-c583-4b5e-b392-3e0ecf487849}" SpecialFunc="None">
     <Declaration><![CDATA[(*
     This function declares a new test (if it has not been already declared in an earlier cycle)
@@ -25,6 +25,7 @@ FOR CounterTestSuiteAddress := 1 TO GVL_TcUnit.NumberOfInitializedTestSuites BY 
     (* Look for the test suite by comparing to the one that is currently running *)
     IF GVL_TcUnit.TestSuiteAddresses[CounterTestSuiteAddress] = GVL_TcUnit.CurrentTestSuiteBeingCalled THEN
         GVL_TcUnit.TestSuiteAddresses[CounterTestSuiteAddress]^.AddTest(TestName := TestName);
+        GVL_TcUnit.CurrentTestIsFinished := GVL_TcUnit.TestSuiteAddresses[CounterTestSuiteAddress]^.IsTestFinished(TestName := TestName);
         RETURN;
     END_IF
 END_FOR]]></ST>
@@ -42,6 +43,7 @@ END_FOR]]></ST>
       <LineId Id="118" Count="0" />
       <LineId Id="99" Count="0" />
       <LineId Id="101" Count="0" />
+      <LineId Id="162" Count="0" />
       <LineId Id="103" Count="0" />
       <LineId Id="102" Count="0" />
       <LineId Id="100" Count="0" />

--- a/TcUnit/TcUnit/POUs/Functions/TEST_FINISHED.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/TEST_FINISHED.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.9">
   <POU Name="TEST_FINISHED" Id="{9922b45b-fca5-4323-be8f-93710371a816}" SpecialFunc="None">
     <Declaration><![CDATA[(* Sets the currently running test as finished *)
 FUNCTION TEST_FINISHED : BOOL
@@ -16,6 +16,7 @@ TEST_FINISHED := FALSE;
 FOR Counter := 1 TO GVL_TcUnit.NumberOfInitializedTestSuites BY 1 DO
     IF GVL_TcUnit.TestSuiteAddresses[Counter] = GVL_TcUnit.CurrentTestSuiteBeingCalled THEN
         GVL_TcUnit.TestSuiteAddresses[Counter]^.SetTestFinished(TestName := GVL_TcUnit.CurrentTestNameBeingCalled);
+        GVL_TcUnit.CurrentTestIsFinished := TRUE;
         TEST_FINISHED := TRUE;
         RETURN;
     END_IF
@@ -28,6 +29,7 @@ END_FOR]]></ST>
       <LineId Id="21" Count="0" />
       <LineId Id="9" Count="0" />
       <LineId Id="16" Count="2" />
+      <LineId Id="38" Count="0" />
       <LineId Id="31" Count="1" />
       <LineId Id="19" Count="0" />
       <LineId Id="15" Count="0" />


### PR DESCRIPTION
# The bug this fixes
I noticed some odd behavior in some tests I was writing. I found out that assert statements were still being evaluated even after a multi-cycle test was finished, so as the variables in my FB continued to change after the test was over, the values started to fail the assertions because the FB had continued into a state that I wasn't testing in that specific test. 

For example:
You have a test suite `MyTestSuite` which has two test methods: `Test_LongTest` and `Test_ShortTest`. 
- `Test_ShortTest` passes all assertions and quickly calls `TEST_FINISHED()`. Some of the variables it had asserted were time-dependent.
- `Test_LongTest` continues to run after `Test_ShortTest` is done, causing the `Test_ShortTest` method to continue being executed.
- Some of the variables in `Test_ShortTest` change because so much time is passing, causing the assertions in there to fail. `Test_ShortTest` is already finished, so this shouldn't matter, but still gets logged in the error output and increases the failed tests count
- A while later, `Test_LongTest` finally finishes, and `MyTestSuite` stops being executed.

# How I fixed it
This PR adds a global variable that keeps track of whether or not the current running test has finished, and, if so, any called `Assert*` methods are skipped.

# Testing
https://github.com/tcunit/TcUnit-Verifier/pull/12
I also ran it on my test I was writing when I found this bug and it fixed it.