### PR TITLE
Tcblack declaration format

### DIFF
--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/POUs/FB_ProtectedVariables.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/POUs/FB_ProtectedVariables.TcPOU
@@ -52,7 +52,8 @@ VAR
     VarUSINT : USINT;
     VarWORD : WORD;
     VarWSTRING : WSTRING;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_AdjustAssertFailureMessageToMax253CharLengthTest.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_AdjustAssertFailureMessageToMax253CharLengthTest.TcPOU
@@ -4,7 +4,8 @@
     <Declaration><![CDATA[(* This testsuite tests the function block FB_AdjustAssertFailureMessageToMax255CharLength_Test
    The total printed message can not be more than 253 characters long.
 *)
-FUNCTION_BLOCK FB_AdjustAssertFailureMessageToMax253CharLengthTest EXTENDS TcUnit.FB_TestSuite]]></Declaration>
+FUNCTION_BLOCK FB_AdjustAssertFailureMessageToMax253CharLengthTest EXTENDS TcUnit.FB_TestSuite
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[TestInstancePath253CharsExpectTooLongTestInstancePath();
 TestInstancePath221CharsExpectShortenedTestInstancePath();
@@ -14,19 +15,20 @@ TestInstancePath255CharsExpectTooLongTestInstancePath();]]></ST>
       <Declaration><![CDATA[METHOD TestInstancePath221CharsExpectShortenedTestInstancePath
 VAR
     AdjustAssertFailureMessageToMax253CharLength : FB_AdjustAssertFailureMessageToMax253CharLength;
-
+    
     // @Text-Fixture
     TestInstancePathNameWith221Chars : Tc2_System.T_MaxString := 'PRG_TEST.LongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceName@LONGTESTNAMELONGTESTNAMELONGTESTNAMELONGTESTNAMELON';
     TooLongTestMessage60Chars : Tc2_System.T_MaxString := 'Very long message that is 60 characters long which means tha';
     
     // @Test-Result-Expected
     // 221 + 32 = 253 (in other words, expected test message should be 32 characters long including '...TestMsg too long'
-    TestMessageResultExpected : Tc2_System.T_MaxString := 'Very long mes...TestMsg too long'; 
-
+    TestMessageResultExpected : Tc2_System.T_MaxString := 'Very long mes...TestMsg too long';
+    
     // @Test-Result
     TestInstancePathResult : Tc2_System.T_MaxString;
     TestMessageResult : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('TestInstancePath221CharsExpectShortenedTestInstancePath');
 
@@ -51,19 +53,20 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD PRIVATE TestInstancePath253CharsExpectTooLongTestInstancePath
 VAR
     AdjustAssertFailureMessageToMax253CharLength : FB_AdjustAssertFailureMessageToMax253CharLength;
-
+    
     // @Text-Fixture
     TestInstancePathNameWith253Chars : Tc2_System.T_MaxString := 'PRG_TEST.LongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceName@LONGTESTNAMELONGTESTNAMELONGTESTNAMELONGTESTNAMELONGTESTNAMELONGTESTNAMELONGTESTNAM';
     ShortTestMessage : Tc2_System.T_MaxString := 'Very short message';
-
+    
     // @Test-Result-Expected
     TestInstancePathNameWith253CharsExpectedResult : Tc2_System.T_MaxString := 'PRG_TEST.LongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceName@LONGTESTNAMELONGTESTNAMELONGTESTNAMELONGTESTNAMELONGTESTNAMELON...TestName too long';
     ShortTestMessageExpectedResult : Tc2_System.T_MaxString := '';
-
+    
     // @Test-Result
     TestInstancePathNameWith253CharsResult : Tc2_System.T_MaxString;
     ShortTestMessageResult : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('TestInstancePath253CharsExpectTooLongTestInstancePath');
 
@@ -87,15 +90,15 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD PRIVATE TestInstancePath255CharsExpectTooLongTestInstancePath
 VAR
     AdjustAssertFailureMessageToMax253CharLength : FB_AdjustAssertFailureMessageToMax253CharLength;
-
+    
     // @Text-Fixture
     TestInstancePathNameWith255Chars : Tc2_System.T_MaxString := 'PRG_TEST.LongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceName@LONGTESTNAMELONGTESTNAMELONGTESTNAMELONGTESTNAMELONGTESTNAMELONGTESTNAMELONGTESTNAGAV';
     ShortTestMessage : Tc2_System.T_MaxString := 'Very short message';
-
+    
     // @Test-Result-Expected
     TestInstancePathNameWith253CharsExpectedResult : Tc2_System.T_MaxString := 'PRG_TEST.LongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceNameLongInstanceName@LONGTESTNAMELONGTESTNAMELONGTESTNAMELONGTESTNAMELONGTESTNAMELON...TestName too long';
     ShortTestMessageExpectedResult : Tc2_System.T_MaxString := '';
-
+    
     // @Test-Result
     TestInstancePathNameWith253CharsResult : Tc2_System.T_MaxString;
     ShortTestMessageResult : Tc2_System.T_MaxString;

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_AnyPrimitiveTypes.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_AnyPrimitiveTypes.TcPOU
@@ -10,7 +10,8 @@
     For every failing test the printed value should be the same as if we were using the primitive data type assert
     directly. 
 *)
-FUNCTION_BLOCK FB_AnyPrimitiveTypes EXTENDS TcUnit.FB_TestSuite]]></Declaration>
+FUNCTION_BLOCK FB_AnyPrimitiveTypes EXTENDS TcUnit.FB_TestSuite
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Test_ANY_BYTE_Equals();
 Test_ANY_BYTE_Differ();
@@ -64,7 +65,8 @@ Test_ANY_WSTRING_Differ_2();]]></ST>
 VAR
     a : BOOL := TRUE;
     b : BOOL := FALSE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_BOOL_Differ');
 
@@ -80,7 +82,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : BOOL := TRUE;
     b : BOOL := TRUE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_BOOL_Equals');
 
@@ -96,7 +99,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : BYTE := 16#AB;
     b : BYTE := 16#CD;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_BYTE_Differ');
 
@@ -112,7 +116,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : BYTE := 16#CD;
     b : BYTE := 16#CD;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_BYTE_Equals');
 
@@ -128,7 +133,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DATE_AND_TIME := DATE_AND_TIME#1996-05-06-15:36:30;
     b : DATE_AND_TIME := DATE_AND_TIME#1972-03-29-00:00:00;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_DATE_AND_TIME_Differ');
 
@@ -144,7 +150,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DATE_AND_TIME := DATE_AND_TIME#2019-01-20-13:54:30;
     b : DATE_AND_TIME := DATE_AND_TIME#2019-01-20-13:54:30;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_DATE_AND_TIME_Equals');
 
@@ -160,7 +167,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DATE := DATE#1996-05-06;
     b : DATE := DATE#2019-01-20;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_DATE_Differ');
 
@@ -176,7 +184,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DATE := DATE#1996-05-06;
     b : DATE := DATE#1996-05-06;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_DATE_Equals');
 
@@ -192,7 +201,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DINT := -55555;
     b : DINT := 70000;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_DINT_Differ');
 
@@ -208,7 +218,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DINT := -80000;
     b : DINT := -80000;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_DINT_Equals');
 
@@ -224,7 +235,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DWORD := 16#12345678;
     b : DWORD := 16#90ABCDEF;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_DWORD_Differ');
 
@@ -240,7 +252,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DWORD := 16#7890ABCD;
     b : DWORD := 16#7890ABCD;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_DWORD_Equals');
 
@@ -256,7 +269,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : INT := -32000;
     b : INT := 15423;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_INT_Differ');
 
@@ -272,7 +286,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : INT := -12345;
     b : INT := -12345;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_INT_Equals');
 
@@ -288,7 +303,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LINT := -451416345;
     b : LINT := 589532453;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_LINT_Differ');
 
@@ -304,7 +320,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LINT := -123456789;
     b : LINT := -123456789;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_LINT_Equals');
 
@@ -320,7 +337,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LREAL := 1234567.89;
     b : LREAL := 1234567.76;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_LREAL_Differ');
 
@@ -336,7 +354,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LREAL := 1234567.89;
     b : LREAL := 1234567.89;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_LREAL_Equals');
 
@@ -352,7 +371,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LTIME := LTIME#213503D23H34M33S709MS551US615NS;
     b : LTIME := LTIME#1000D15H23M12S34MS2US44NS;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_LTIME_Differ');
 
@@ -368,7 +388,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LTIME := LTIME#213503D23H34M33S709MS551US615NS;
     b : LTIME := LTIME#213503D23H34M33S709MS551US615NS;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_LTIME_Equals');
 
@@ -384,7 +405,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LWORD := 16#0123656789ABCBEC;
     b : LWORD := 16#0123256789ABCAEE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_LWORD_Differ');
 
@@ -400,7 +422,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LWORD := 16#0123456789ABCDEF;
     b : LWORD := 16#0123456789ABCDEF;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_LWORD_Equals');
 
@@ -416,7 +439,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : REAL := 1234.5;
     b : REAL := 1234.4;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_REAL_Differ');
 
@@ -432,7 +456,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : REAL := 1234.5;
     b : REAL := 1234.5;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_REAL_Equals');
 
@@ -448,7 +473,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : SINT := 127;
     b : SINT := -30;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_SINT_Differ');
 
@@ -464,7 +490,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : SINT := -128;
     b : SINT := -128;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_SINT_Equals');
 
@@ -480,7 +507,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : STRING := 'This is a string';
     b : STRING := 'This is another string';
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_STRING_Differ');
 
@@ -496,7 +524,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : STRING := 'This is a string';
     b : STRING := 'This is b string';
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_STRING_Differ_2');
 
@@ -512,7 +541,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : STRING := 'Hello there';
     b : STRING := 'Hello there';
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_STRING_Equals');
 
@@ -528,7 +558,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : TIME := T#12H34M15S10MS;
     b : TIME := T#11H34M13S244MS;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_TIME_Differ');
 
@@ -544,7 +575,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : TIME := T#11H34M13S244MS;
     b : TIME := T#11H34M13S244MS;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_TIME_Equals');
 
@@ -560,7 +592,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : TIME_OF_DAY := TIME_OF_DAY#15:36:30.123;
     b : TIME_OF_DAY := TIME_OF_DAY#06:21:11.492;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_TIME_OF_DAY_Differ');
 
@@ -576,7 +609,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : TIME_OF_DAY := TIME_OF_DAY#06:21:11.492;
     b : TIME_OF_DAY := TIME_OF_DAY#06:21:11.492;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_TIME_OF_DAY_Equals');
 
@@ -592,7 +626,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : UDINT := 34124214;
     b : UDINT := 52343244;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_UDINT_Differ');
 
@@ -608,7 +643,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : UDINT := 21845123;
     b : UDINT := 21845123;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_UDINT_Equals');
 
@@ -624,7 +660,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : UINT := 64322;
     b : UINT := 32312;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_UINT_Differ');
 
@@ -640,7 +677,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : UINT := 65535;
     b : UINT := 65535;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_UINT_Equals');
 
@@ -656,7 +694,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ULINT := 10000;
     b : ULINT := 53685437234;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_ULINT_Differ');
 
@@ -672,7 +711,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ULINT := 45683838383;
     b : ULINT := 45683838383;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_ULINT_Equals');
 
@@ -688,7 +728,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : USINT := 3;
     b : USINT := 7;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_USINT_Differ');
 
@@ -704,7 +745,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : USINT := 5;
     b : USINT := 5;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_USINT_Equals');
 
@@ -720,7 +762,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : WORD := 16#EF01;
     b : WORD := 16#2345;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_WORD_Differ');
 
@@ -736,7 +779,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : WORD := 16#ABCD;
     b : WORD := 16#ABCD;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_WORD_Equals');
 
@@ -752,7 +796,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : WSTRING := "äö";
     b : WSTRING := "æå";
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_WSTRING_Differ');
 
@@ -768,7 +813,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : WSTRING := "äö◦";
     b : WSTRING := "æå";
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_WSTRING_Differ_2');
 
@@ -784,7 +830,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : WSTRING := "ĠĦ";
     b : WSTRING := "ĠĦ";
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_WSTRING_Equals');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_AnyToUnionValue.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_AnyToUnionValue.TcPOU
@@ -7,7 +7,8 @@
 FUNCTION_BLOCK FB_AnyToUnionValue EXTENDS TcUnit.FB_TestSuite
 VAR
     aBit : BIT := 1; // Only structures and function blocks can have BIT defined
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Test_BOOL();
 Test_BIT();
@@ -38,7 +39,8 @@ Test_LTIME();]]></ST>
       <Declaration><![CDATA[METHOD PRIVATE Test_BIT
 VAR
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BIT');
 
@@ -56,7 +58,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : BOOL := TRUE;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BOOL');
 
@@ -74,7 +77,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : BYTE := 16#8A;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BYTE');
 
@@ -92,7 +96,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DATE := D#2106-02-05;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DATE');
 
@@ -110,7 +115,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DATE_AND_TIME := DT#2106-02-06-06:28:15;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DATE_AND_TIME');
 
@@ -128,7 +134,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DINT := 143251;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DINT');
 
@@ -146,7 +153,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DWORD := 16#3456CDEF;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DWORD');
 
@@ -164,7 +172,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : INT := -32000;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_INT');
 
@@ -182,7 +191,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LINT := -31243145;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LINT');
 
@@ -200,7 +210,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LREAL := 43123923124.745423;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL');
 
@@ -218,7 +229,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LTIME := LTIME#213502D23H34M33S709MS551US615NS;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LTIME');
 
@@ -236,7 +248,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LWORD := 16#456CDEF987654321;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LWORD');
 
@@ -254,7 +267,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : REAL := 431239.423;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL');
 
@@ -272,7 +286,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : SINT := 100;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_SINT');
 
@@ -290,7 +305,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : STRING := 'This is a random string';
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_STRING');
 
@@ -308,7 +324,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : Tc2_System.T_MaxString := '8YNn5KOmPC4dAcpOBdLWnw4WkN126EwXsj65xeurG48gWBepinNaOIKeCVMtWNBSxQWPdtUYiAusDkjMLtQhDtiWbwvmoKcFwiUGDd7pOe0fd52J7hK60oaYAX6VWWmceLJX8utaDVrVzCGXafeZLeHl6jj5enfjg4tfb2WMEBdsBuG2iDKwzwhBLCPqXDnhe5HbemIbtZT7p62OEj2oDqiIYDD6tZdlhBCCelDBx6dbIp32wFm0TpRKsTiwkZ6'; // 255 characters
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_STRING_2');
 
@@ -326,7 +343,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : TIME := T#15M20S;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_TIME');
 
@@ -344,7 +362,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : TIME_OF_DAY := TOD#15:36:30.123;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_TIME_OF_DAY');
 
@@ -362,7 +381,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : UDINT := 2555;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_UDINT');
 
@@ -380,7 +400,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : UINT := 34523;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_UINT');
 
@@ -398,7 +419,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ULINT := 25555423;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('TEST_ULINT');
 
@@ -416,7 +438,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : USINT := 255;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_USINT');
 
@@ -434,7 +457,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : WORD := 16#ABCD;
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WORD');
 
@@ -452,7 +476,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : WSTRING := "åäöĦ";
     result : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WSTRING');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_ArrayPrimitiveTypes.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_ArrayPrimitiveTypes.TcPOU
@@ -9,7 +9,8 @@
         2. One test that fails, where the size of the arrays differs
         3. One test that fails, where the content of the array differs
 *)
-FUNCTION_BLOCK FB_ArrayPrimitiveTypes EXTENDS TcUnit.FB_TestSuite]]></Declaration>
+FUNCTION_BLOCK FB_ArrayPrimitiveTypes EXTENDS TcUnit.FB_TestSuite
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Test_BOOL_Array_Equals();
 Test_BOOL_Array_DifferInSize();
@@ -89,7 +90,8 @@ Test_WORD_Array_DifferInContent();
 VAR
     a : ARRAY[0..5] OF BOOL := [TRUE, TRUE, FALSE, TRUE, FALSE, TRUE];
     b : ARRAY[0..5] OF BOOL := [TRUE, TRUE, TRUE, TRUE, FALSE, FALSE];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BOOL_Array_DifferInContent');
 
@@ -105,7 +107,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[1..6] OF BOOL := [TRUE, TRUE, TRUE, TRUE, TRUE, TRUE];
     b : ARRAY[1..4] OF BOOL := [TRUE, TRUE, TRUE, TRUE];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BOOL_Array_DifferInSize');
 
@@ -121,7 +124,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[1..5] OF BOOL := [TRUE, FALSE, TRUE, FALSE, TRUE];
     b : ARRAY[1..5] OF BOOL := [TRUE, FALSE, TRUE, FALSE, TRUE];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BOOL_Array_Equals');
 
@@ -137,7 +141,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[0..3] OF BYTE := [16#AB, 16#AA, 16#BB, 16#89];
     b : ARRAY[0..3] OF BYTE := [16#AB, 16#CD, 16#BB, 16#89];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BYTE_Array_DifferInContent');
 
@@ -153,7 +158,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[1..2] OF BYTE := [16#AB, 16#CD];
     b : ARRAY[1..5] OF BYTE := [16#AB, 16#CD, 16#EF, 16#01, 16#23];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BYTE_Array_DifferInSize');
 
@@ -169,7 +175,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[1..3] OF BYTE := [16#FD, 16#34, 16#9E];
     b : ARRAY[1..3] OF BYTE := [16#FD, 16#34, 16#9E];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BYTE_Array_Equals');
 
@@ -185,7 +192,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[3..5] OF DINT := [-4746, -2147483645, 0];
     b : ARRAY[3..5] OF DINT := [-4746, -2147483641, 0];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DINT_Array_DifferInContent');
 
@@ -201,7 +209,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[3..4] OF DINT := [-11, 2147483647];
     b : ARRAY[4..6] OF DINT := [-11, 2147483647, 0];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DINT_Array_DifferInSize');
 
@@ -217,7 +226,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[2..7] OF DINT := [64, 98, 2147483647, -2147483648, 0, -63987538];
     b : ARRAY[2..7] OF DINT := [64, 98, 2147483647, -2147483648, 0, -63987538];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DINT_Array_Equals');
 
@@ -233,7 +243,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-2..1] OF DWORD := [16#6789ABCD, 16#EFAA2346, 16#ABABABAB, 16#EEEEEEEE];
     b : ARRAY[-2..1] OF DWORD := [16#6789ABCD, 16#EF012345, 16#ABABABAB, 16#EEEEEEEE];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DWORD_Array_DifferInContent');
 
@@ -249,7 +260,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-2..1] OF DWORD := [16#6789ABCD, 16#EF012345, 16#67890ABC, 16#DDDDDDDD];
     b : ARRAY[-3..-2] OF DWORD := [16#6789ABCD, 16#EF012345];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DWORD_Array_DifferInSize');
 
@@ -265,7 +277,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[2..3] OF DWORD := [16#6789ABCD, 16#EF012345];
     b : ARRAY[1..2] OF DWORD := [16#6789ABCD, 16#EF012345];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DWORD_Array_Equals');
 
@@ -281,7 +294,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-8..-6] OF INT := [42, -23, -32768];
     b : ARRAY[1..3] OF INT := [42, 24, -32768];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_INT_Array_DifferInContent');
 
@@ -297,7 +311,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-4..3] OF INT := [64, 98, -32768, 32767, 5478, -378, 42, 6234];
     b : ARRAY[1..5] OF INT := [64, 98, -32768, 32767, 5478];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_INT_Array_DifferInSize');
 
@@ -313,7 +328,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-5..1] OF INT := [64, 98, -32768, 32767, 5478, -378, 42];
     b : ARRAY[1..7] OF INT := [64, 98, -32768, 32767, 5478, -378, 42];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_INT_Array_Equals');
 
@@ -329,7 +345,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-1..1] OF LINT := [9_223_372_036_854_775_807, -9_223_372_036_853_775_808, 55];
     b : ARRAY[4..6] OF LINT := [9_223_372_036_854_775_807, -9_223_372_036_854_775_808, 55];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LINT_Array_DifferInContent');
 
@@ -345,7 +362,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-1..1] OF LINT := [9_223_372_036_854_775_807, -9_223_372_036_854_775_808, 55];
     b : ARRAY[4..5] OF LINT := [9_223_372_036_854_775_807, -9_223_372_036_854_775_808];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LINT_Array_DifferInSize');
 
@@ -361,7 +379,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-1..0] OF LINT := [9_223_372_036_854_775_807, -9_223_372_036_854_775_808];
     b : ARRAY[4..5] OF LINT := [9_223_372_036_854_775_807, -9_223_372_036_854_775_808];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LINT_Array_Equals');
 
@@ -377,7 +396,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-8..-6] OF LREAL := [42, -23, -32768];
     b : ARRAY[1..3] OF LREAL := [42, 24, -32768];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array_DifferInContent');
 
@@ -394,7 +414,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-4..3] OF LREAL := [64, 98, -32768, 32767, 5478, -378, 42, 6234];
     b : ARRAY[1..5] OF LREAL := [64, 98, -32768, 32767, 5478];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array_DifferInSize');
 
@@ -411,7 +432,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-5..1] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6];
     b : ARRAY[1..7] OF LREAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array_Equals');
 
@@ -429,11 +451,12 @@ VAR
     a : ARRAY[-5..-3,-1..1] OF LREAL := [      0,                        0.75069381424723836,      0.29093464244666262,     
                                                0.034287043863109802,     0.4487738206278411,       0.53067566153159162,      
                                                0.30748602156875937,      0.63373366540006071,      0.0090356068727726144 ];
-                                                    
+    
     b : ARRAY[0..2,3..5] OF LREAL :=   [       1,                        0.75069381424723836,      0.29093464244666262,     
                                                0.034287043883109802,     0.4487738206278411,       0.53067566153159162,      
                                                0.30748602156875937,      0.63373366540006071,      0.0090356068727726144 ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array2d_DifferInContent_LBOUND');
 
@@ -451,11 +474,12 @@ VAR
     a : ARRAY[-5..-3,-1..1] OF LREAL := [      0.39153705462419292,      0.75069381424723836,      0.29093464244666262,     
                                                0.034287043863109802,     0,                        0.53067566153159162,      
                                                0.30748602156875937,      0.63373366540006071,      0.0090356068727726144 ];
-                                                    
+    
     b : ARRAY[0..2,3..5] OF LREAL :=   [       0.39153705462419292,      0.75069381424723836,      0.29093464244666262,     
                                                0.034287043883109802,     1,                        0.53067566153159162,      
                                                0.30748602156875937,      0.63373366540006071,      0.0090356068727726144 ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array2d_DifferInContent_Middle');
 
@@ -473,11 +497,12 @@ VAR
     a : ARRAY[-5..-3,-1..1] OF LREAL := [      0.39153705462419292,      0.75069381424723836,      0.29093464244666262,     
                                                0.034287043863109802,     0.4487738206278411,       0.53067566153159162,      
                                                0.30748602156875937,      0.63373366540006071,      0                     ];
-                                                    
+    
     b : ARRAY[0..2,3..5] OF LREAL :=   [       0.39153705462419292,      0.75069381424723836,      0.29093464244666262,     
                                                0.034287043883109802,     0.4487738206278411,       0.53067566153159162,      
                                                0.30748602156875937,      0.63373366540006071,      1                     ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array2d_DifferInContent_UBOUND');
 
@@ -496,10 +521,11 @@ VAR
     a : ARRAY[-4..-2, -1..0] OF LREAL := [    1.004110987573404E+62,  -2.873296335229452E+224,  
                                              -3.5901630626493139E+58, -1.0170839179102032E+220, 
                                              -1.1922268785979511E+79, -1.9309907712685427E+64    ];
-                                           
+    
     b : ARRAY[1..2, 0..1] OF LREAL := [       1.004110987573404E+62,  -2.873296335229452E+224,  
                                             -3.5901630626493139E+58,  -1.0170839179102032E+220   ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array2d_DifferInSize_D1');
 
@@ -517,10 +543,11 @@ METHOD PRIVATE Test_LREAL_Array2d_DifferInSize_D2
 VAR
     a : ARRAY[-4..-3, -1..0] OF LREAL := [    1.004110987573404E+62,  -2.873296335229452E+224,  
                                              -3.5901630626493139E+58, -1.0170839179102032E+220    ];
-                                           
+    
     b : ARRAY[1..2, 0..2] OF LREAL :=    [    1.004110987573404E+62,  -2.873296335229452E+224,  -3.5901630626493139E+58,  
                                             -1.0170839179102032E+220,  -1.1922268785979511E+79,  -1.9309907712685427E+64  ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array2d_DifferInSize_D2');
 
@@ -535,9 +562,10 @@ TEST_FINISHED();]]></ST>
     <Method Name="Test_LREAL_Array2d_Equals" Id="{78fed880-525c-48dc-8dc2-6a8b82a2b4e4}">
       <Declaration><![CDATA[METHOD PRIVATE Test_LREAL_Array2d_Equals
 VAR
-    a : ARRAY[-5..-3,-1..0] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5];
-    b : ARRAY[1..3,0..1] OF LREAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003];
-END_VAR]]></Declaration>
+    a : ARRAY[-5..-3, -1..0] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5];
+    b : ARRAY[1..3, 0..1] OF LREAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003];
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array2d_Equals');
 
@@ -555,27 +583,28 @@ VAR
     a : ARRAY[-5..-3,-1..1,1..3] OF LREAL := [      0,                        0.75069381424723836,      0.29093464244666262,     
                                                     0.034287043863109802,     0.4487738206278411,       0.53067566153159162,      
                                                     0.30748602156875937,      0.63373366540006071,      0.0090356068727726144,      
-
+    
                                                     0.86311411432135576,      0.56920950420629679,      0.10704580466591092,
                                                     0.99235347099246152,      0.64118643600548919,      0.53803785449733854,
                                                     0.8536550946783531,       0.40930482857362593,      0.96201282039378433,
-
+    
                                                     0.98258493467354446,      0.14997228521386732,      0.36854104388902942,
                                                     0.45163352808525487,      0.17645537628627167,      0.02055403311762681,
                                                     0.15098329919901829,      0.099172453907864375,     0.04804534513877954  ];
-                                                    
+    
     b : ARRAY[0..2,3..5,5..7] OF LREAL :=   [       1,                        0.75069381424723836,      0.29093464244666262,     
                                                     0.034287043883109802,     0.4487738206278411,       0.53067566153159162,      
                                                     0.30748602156875937,      0.63373366540006071,      0.0090356068727726144,      
-
+    
                                                     0.86311411432135576,      0.56920950420629679,      0.10704582466591092,
                                                     0.99235347099246152,      0.64118643600548919,      0.53803785449733854,
                                                     0.8536556946783531,       0.40930482857362593,      0.96201282039378433,
-
+    
                                                     0.98258493467354446,      0.14997228521386732,      0.36854104388952942,
                                                     0.45163352803525487,      0.17645537628627167,      0.02055403311762681,
                                                     0.15098329919901829,      0.099172453907864375,     0.04804534513877954  ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array3d_DifferInContent_LBOUND');
 
@@ -593,27 +622,28 @@ VAR
     a : ARRAY[-5..-3,-1..1,1..3] OF LREAL := [      0.39153705462419292,      0.75069381424723836,      0.29093464244666262,     
                                                     0.034287043863109802,     0.4487738206278411,       0.53067566153159162,      
                                                     0.30748602156875937,      0.63373366540006071,      0.0090356068727726144,      
-
+    
                                                     0.86311411432135576,      0.56920950420629679,      0.10704580466591092,
                                                     0.99235347099246152,      0,                        0.53803785449733854,
                                                     0.8536550946783531,       0.40930482857362593,      0.96201282039378433,
-
+    
                                                     0.98258493467354446,      0.14997228521386732,      0.36854104388902942,
                                                     0.45163352808525487,      0.17645537628627167,      0.02055403311762681,
                                                     0.15098329919901829,      0.099172453907864375,     0.04804534513877954  ];
-                                                    
+    
     b : ARRAY[0..2,3..5,5..7] OF LREAL :=   [       0.39153705462419292,      0.75069381424723836,      0.29093464244666262,     
                                                     0.034287043883109802,     0.4487738206278411,       0.53067566153159162,      
                                                     0.30748602156875937,      0.63373366540006071,      0.0090356068727726144,      
-
+    
                                                     0.86311411432135576,      0.56920950420629679,      0.10704582466591092,
                                                     0.99235347099246152,      1,                        0.53803785449733854,
                                                     0.8536556946783531,       0.40930482857362593,      0.96201282039378433,
-
+    
                                                     0.98258493467354446,      0.14997228521386732,      0.36854104388952942,
                                                     0.45163352803525487,      0.17645537628627167,      0.02055403311762681,
                                                     0.15098329919901829,      0.099172453907864375,     0.04804534513877954  ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array3d_DifferInContent_Middle');
 
@@ -631,27 +661,28 @@ VAR
     a : ARRAY[-5..-3,-1..1,1..3] OF LREAL := [      0.39153705462419292,      0.75069381424723836,      0.29093464244666262,     
                                                     0.034287043863109802,     0.4487738206278411,       0.53067566153159162,      
                                                     0.30748602156875937,      0.63373366540006071,      0.0090356068727726144,      
-
+    
                                                     0.86311411432135576,      0.56920950420629679,      0.10704580466591092,
                                                     0.99235347099246152,      0.64118643600548919,      0.53803785449733854,
                                                     0.8536550946783531,       0.40930482857362593,      0.96201282039378433,
-
+    
                                                     0.98258493467354446,      0.14997228521386732,      0.36854104388902942,
                                                     0.45163352808525487,      0.17645537628627167,      0.02055403311762681,
                                                     0.15098329919901829,      0.099172453907864375,     0                     ];
-                                                    
+    
     b : ARRAY[0..2,3..5,5..7] OF LREAL :=   [       0.39153705462419292,      0.75069381424723836,      0.29093464244666262,     
                                                     0.034287043883109802,     0.4487738206278411,       0.53067566153159162,      
                                                     0.30748602156875937,      0.63373366540006071,      0.0090356068727726144,      
-
+    
                                                     0.86311411432135576,      0.56920950420629679,      0.10704582466591092,
                                                     0.99235347099246152,      0.64118643600548919,      0.53803785449733854,
                                                     0.8536556946783531,       0.40930482857362593,      0.96201282039378433,
-
+    
                                                     0.98258493467354446,      0.14997228521386732,      0.36854104388952942,
                                                     0.45163352803525487,      0.17645537628627167,      0.02055403311762681,
                                                     0.15098329919901829,      0.099172453907864375,     1                     ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array3d_DifferInContent_UBOUND');
 
@@ -671,7 +702,7 @@ VAR
     a : ARRAY[-5..-4,0..2,-1..0] OF LREAL := [    2.082350040687358E+68,     1.0648482884583467E-159,  
                                                   2.6081154219341126E+236,  -2.2453945418753555E+134,  
                                                   8.5957093309297743E+301,  -5.9598471182139549E-139,  
-
+    
                                                   -7.2419908660524697E+76,  5.0020389252645754E-160,  
                                                   -3.3631038290869421E-213,  -1.4376587532865779E+110,  
                                                   -1.0876803662003504E-263,  3.2352832374899203E+165  ];
@@ -680,15 +711,16 @@ VAR
     b : ARRAY[0..2,3..5,6..7] OF LREAL := [    2.082350040687358E+68,     1.0648482884583467E-159,  
                                                   2.6081154219341126E+236,  -2.2453945418753555E+134,  
                                                   8.5957093309297743E+301,  -5.9598471182139549E-139,  
-
+    
                                                   -7.2419908660524697E+76,  5.0020389252645754E-160,  
                                                   -3.3631038290869421E-213,  -1.4376587532865779E+110,  
                                                   -1.0876803662003504E-263,  3.2352832374899203E+165,
-
+    
                                                   -4.6404382914454893E-67,  -1.3556949396573763E-104,  
                                                   -1.1830864377130754E+146,       7737.6071934405209,      
                                                   -470928678.08185887,       2.1842539859532993E-126    ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array3d_DifferInSize_D1');
 
@@ -708,7 +740,7 @@ VAR
     a : ARRAY[-5..-4,0..2,-1..0] OF LREAL := [    2.082350040687358E+68,     1.0648482884583467E-159,  
                                                   2.6081154219341126E+236,  -2.2453945418753555E+134,  
                                                   8.5957093309297743E+301,  -5.9598471182139549E-139,  
-
+    
                                                   -7.2419908660524697E+76,  5.0020389252645754E-160,  
                                                   -3.3631038290869421E-213,  -1.4376587532865779E+110,  
                                                   -1.0876803662003504E-263,  3.2352832374899203E+165  ];
@@ -716,10 +748,11 @@ VAR
     // 2x2x2
     b : ARRAY[0..1,3..4,6..7] OF LREAL := [       2.082350040687358E+68,     1.0648482884583467E-159,  
                                                   2.6081154219341126E+236,  -2.2453945418753555E+134, 
- 
+    
                                                   8.5957093309297743E+301,  -5.9598471182139549E-139,  
                                                   -7.2419908660524697E+76,  5.0020389252645754E-160  ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array3d_DifferInSize_D2');
 
@@ -739,7 +772,7 @@ VAR
     a : ARRAY[-5..-4,0..2,-1..0] OF LREAL := [    2.082350040687358E+68,     1.0648482884583467E-159,  
                                                   2.6081154219341126E+236,  -2.2453945418753555E+134,  
                                                   8.5957093309297743E+301,  -5.9598471182139549E-139,  
-
+    
                                                   -7.2419908660524697E+76,  5.0020389252645754E-160,  
                                                   -3.3631038290869421E-213,  -1.4376587532865779E+110,  
                                                   -1.0876803662003504E-263,  3.2352832374899203E+165  ];
@@ -748,11 +781,12 @@ VAR
     b : ARRAY[0..1,3..5,6..6] OF LREAL := [       2.082350040687358E+68,     
                                                   1.0648482884583467E-159,  
                                                   2.6081154219341126E+236,  
-
+    
                                                  -2.2453945418753555E+134,
                                                   8.5957093309297743E+301,  
                                                  -5.9598471182139549E-139  ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array3d_DifferInSize_D3');
 
@@ -767,9 +801,10 @@ TEST_FINISHED();]]></ST>
     <Method Name="Test_LREAL_Array3d_Equals" Id="{35a98408-a9d2-467b-ab41-be1336f4d5d1}">
       <Declaration><![CDATA[METHOD PRIVATE Test_LREAL_Array3d_Equals
 VAR
-    a : ARRAY[-5..-4,-1..0,0..1] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6, 560344.0005];
-    b : ARRAY[1..2,4..5,6..7] OF LREAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001, 560344.0006];
-END_VAR]]></Declaration>
+    a : ARRAY[-5..-4, -1..0, 0..1] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6, 560344.0005];
+    b : ARRAY[1..2, 4..5, 6..7] OF LREAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001, 560344.0006];
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Array3d_Equals');
 
@@ -786,7 +821,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[1..1] OF LWORD := [16#EDCBA09876543210];
     b : ARRAY[1..1] OF LWORD := [16#01234567890ABCDE];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LWORD_Array_DifferInContent');
 
@@ -802,7 +838,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[1..1] OF LWORD := [16#EDCBA09876543210];
     b : ARRAY[1..2] OF LWORD := [16#01234567890ABCDE, 16#EDCBA09876543210];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LWORD_Array_DifferInSize');
 
@@ -818,7 +855,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[1..2] OF LWORD := [16#01234567890ABCDE, 16#EDCBA09876543210];
     b : ARRAY[1..2] OF LWORD := [16#01234567890ABCDE, 16#EDCBA09876543210];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LWORD_Array_Equals');
 
@@ -834,7 +872,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-8..-6] OF REAL := [42, -23, -32768];
     b : ARRAY[1..3] OF REAL := [42, 24, -32768];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array_DifferInContent');
 
@@ -851,7 +890,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-4..3] OF REAL := [64, 98, -32768, 32767, 5478, -378, 42, 6234];
     b : ARRAY[1..5] OF REAL := [64, 98, -32768, 32767, 5478];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array_DifferInSize');
 
@@ -868,7 +908,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-5..1] OF REAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6];
     b : ARRAY[1..7] OF REAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array_Equals');
 
@@ -886,11 +927,12 @@ VAR
     a : ARRAY[-5..-3,-1..1] OF REAL := [      0,                0.349414557,      0.806114793,      
                                               0.832643092,      0.676487744,      0.422208548,       
                                                0.58663553,      0.108467624,      0.153285101  ];
-                                               
+    
     b : ARRAY[1..3,0..2] OF REAL :=    [      1,               0.349414557,      0.80611479,      
                                               0.83264309,      0.67648774,      0.42220855,       
                                                0.5866355,      0.108467624,      0.153285101  ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array2d_DifferInContent_LBOUND');
 
@@ -908,11 +950,12 @@ VAR
     a : ARRAY[-5..-3,-1..1] OF REAL := [      0.555157363,      0.349414557,      0.806114793,      
                                               0.832643092,      0,                0.422208548,       
                                                0.58663553,      0.108467624,      0.153285101  ];
-                                               
+    
     b : ARRAY[1..3,0..2] OF REAL :=    [      0.555157363,      0.349414557,      0.80611479,      
                                               0.83264309,      1,                 0.42220855,       
                                                0.5866355,      0.108467624,       0.153285101  ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array2d_DifferInContent_Middle');
 
@@ -930,11 +973,12 @@ VAR
     a : ARRAY[-5..-3,-1..1] OF REAL := [      0.555157363,      0.349414557,      0.806114793,      
                                               0.832643092,      0.676487744,      0.422208548,       
                                                0.58663553,      0.108467624,      0           ];
-                                               
+    
     b : ARRAY[1..3,0..2] OF REAL :=    [      0.555157363,      0.349414557,      0.80611479,      
                                               0.83264309,      0.67648774,      0.42220855,       
                                                0.5866355,      0.108467624,      1            ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array2d_DifferInContent_UBOUND');
 
@@ -953,10 +997,11 @@ VAR
     a : ARRAY[-4..-2, -1..0] OF REAL := [   6.89723951E-35, 1.255877E-08,   
                                             1.31490056E+30, 1.0130173,
                                             7.50187543E-38, -698122.938  ];
-                                           
+    
     b : ARRAY[1..2, 0..1] OF REAL :=    [   6.89723951E-35, 1.255877E-08,   
                                             1.31490056E+30, 1.0130173   ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array2d_DifferInSize_D1');
 
@@ -974,10 +1019,11 @@ METHOD PRIVATE Test_REAL_Array2d_DifferInSize_D2
 VAR
     a : ARRAY[-4..-3, -1..0] OF REAL := [   6.89723951E-35, 1.255877E-08,
                                             1.31490056E+30, 1.0130173   ];
-                                           
+    
     b : ARRAY[1..2, 0..2] OF REAL :=    [   6.89723951E-35, 1.255877E-08,   1.31490056E+30,
                                             1.0130173,      7.50187543E-38,   -698122.938  ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array2d_DifferInSize_D2');
 
@@ -992,9 +1038,10 @@ TEST_FINISHED();]]></ST>
     <Method Name="Test_REAL_Array2d_Equals" Id="{c2e03616-7116-4142-98e9-1cdbbf9188f6}">
       <Declaration><![CDATA[METHOD PRIVATE Test_REAL_Array2d_Equals
 VAR
-    a : ARRAY[-5..-3,-1..0] OF REAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5];
-    b : ARRAY[1..3,0..1] OF REAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003];
-END_VAR]]></Declaration>
+    a : ARRAY[-5..-3, -1..0] OF REAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5];
+    b : ARRAY[1..3, 0..1] OF REAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003];
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array2d_Equals');
 
@@ -1012,27 +1059,28 @@ VAR
     a : ARRAY[-5..-3,-1..1,0..2] OF REAL := [       0,                0.349414557,     0.806114793,      
                                                     0.832643092,      0.676487744,     0.422208548,       
                                                     0.58663553,       0.108467624,     0.153285101,      
-
+    
                                                     0.331847638,      0.518251598,     0.396329135,       
                                                     0.68058759,       0.837357402,     0.0384598672,      
                                                     0.485841662,      0.103918776,     0.662022889,      
-
+    
                                                     0.576529145,      0.341899037,     0.375482976,       
                                                     0.77158308,       0.64138025,      0.780365825,      
                                                     0.680897593,      0.451427311,     0.151570886  ];
-                                                    
+    
     b : ARRAY[1..3,3..5,6..8] OF REAL :=    [       1,                0.349414557,     0.806116793,      
                                                     0.832643092,      0.676487744,     0.422208548,       
                                                     0.58663553,       0.108467624,     0.153285101,      
-
+    
                                                     0.331847638,      0.518251598,     0.396329135,       
                                                     0.68058759,       0.837357402,     0.0384598672,      
                                                     0.485844662,      0.103918776,     0.662022889,      
-
+    
                                                     0.576529145,      0.341899037,     0.375482976,       
                                                     0.77158308,       0.64138125,      0.780365825,      
                                                     0.680897593,      0.451427311,     0.151520886  ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array3d_DifferInContent_LBOUND');
 
@@ -1050,27 +1098,28 @@ VAR
     a : ARRAY[-5..-3,-1..1,0..2] OF REAL := [       0.555157363,      0.349414557,     0.806114793,      
                                                     0.832643092,      0.676487744,     0.422208548,       
                                                     0.58663553,       0.108467624,     0.153285101,      
-
+    
                                                     0.331847638,      0.518251598,     0.396329135,       
                                                     0.68058759,       0,               0.0384598672,      
                                                     0.485841662,      0.103918776,     0.662022889,      
-
+    
                                                     0.576529145,      0.341899037,     0.375482976,       
                                                     0.77158308,       0.64138025,      0.780365825,      
                                                     0.680897593,      0.451427311,     0.151570886  ];
-                                                    
+    
     b : ARRAY[1..3,3..5,6..8] OF REAL :=    [       0.555157363,      0.349414557,     0.806116793,      
                                                     0.832643092,      0.676487744,     0.422208548,       
                                                     0.58663553,       0.108467624,     0.153285101,      
-
+    
                                                     0.331847638,      0.518251598,     0.396329135,       
                                                     0.68058759,       1,               0.0384598672,      
                                                     0.485844662,      0.103918776,     0.662022889,      
-
+    
                                                     0.576529145,      0.341899037,     0.375482976,       
                                                     0.77158308,       0.64138125,      0.780365825,      
                                                     0.680897593,      0.451427311,     0.151520886  ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array3d_DifferInContent_Middle');
 
@@ -1088,27 +1137,28 @@ VAR
     a : ARRAY[-5..-3,-1..1,0..2] OF REAL := [       0.555157363,      0.349414557,     0.806114793,      
                                                     0.832643092,      0.676487744,     0.422208548,       
                                                     0.58663553,       0.108467624,     0.153285101,      
-
+    
                                                     0.331847638,      0.518251598,     0.396329135,       
                                                     0.68058759,       0.837357402,     0.0384598672,      
                                                     0.485841662,      0.103918776,     0.662022889,      
-
+    
                                                     0.576529145,      0.341899037,     0.375482976,       
                                                     0.77158308,       0.64138025,      0.780365825,      
                                                     0.680897593,      0.451427311,     0              ];
-                                                    
+    
     b : ARRAY[1..3,3..5,6..8] OF REAL :=    [       0.555157363,      0.349414557,     0.806116793,      
                                                     0.832643092,      0.676487744,     0.422208548,       
                                                     0.58663553,       0.108467624,     0.153285101,      
-
+    
                                                     0.331847638,      0.518251598,     0.396329135,       
                                                     0.68058759,       0.837357402,     0.0384598672,      
                                                     0.485844662,      0.103918776,     0.662022889,      
-
+    
                                                     0.576529145,      0.341899037,     0.375482976,       
                                                     0.77158308,       0.64138125,      0.780365825,      
                                                     0.680897593,      0.451427311,     1              ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array3d_DifferInContent_UBOUND');
 
@@ -1128,16 +1178,17 @@ VAR
     a : ARRAY[-5..-4,1..3,-2..-1] OF REAL := [   4.10516757E-36,        666455872,  
                                                  -6.32274414E-23,   2.51930489E-20,      
                                                 -13.6131887,        6.56142373E+29,   
-
+    
                                                  -7.4229119E+36,   -1.19216618E+17,  
                                                  -1.76541143E+10,   1.06367558E+38,   
                                                   9.62853863E+24,  -1.02125985E-17  ];
-                                                  
+    
     // 1x3x2                                      
     b : ARRAY[1..1,4..6,6..7] OF REAL :=  [   4.10516757E-36,        666455872,  
                                                  -6.32274414E-23,   2.51930489E-20,      
                                                 -13.6131887,        6.56142373E+29 ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array3d_DifferInSize_D1');
 
@@ -1157,18 +1208,19 @@ VAR
     a : ARRAY[-5..-4,1..3,-2..-1] OF REAL := [   4.10516757E-36,        666455872,  
                                                  -6.32274414E-23,   2.51930489E-20,      
                                                 -13.6131887,        6.56142373E+29,   
-
+    
                                                  -7.4229119E+36,   -1.19216618E+17,  
                                                  -1.76541143E+10,   1.06367558E+38,   
                                                   9.62853863E+24,  -1.02125985E-17  ];
-
+    
     // 2x2x2                                      
     b : ARRAY[1..2,4..5,6..7] OF REAL :=  [       4.10516757E-36,        666455872,  
                                                  -6.32274414E-23,   2.51930489E-20,      
-
+    
                                                 -13.6131887,        6.56142373E+29,   
                                                  -7.4229119E+36,   -1.19216618E+17  ];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array3d_DifferInSize_D2');
 
@@ -1188,20 +1240,21 @@ VAR
     a : ARRAY[-5..-4,1..3,-2..-1] OF REAL := [   4.10516757E-36,        666455872,  
                                                  -6.32274414E-23,   2.51930489E-20,      
                                                 -13.6131887,        6.56142373E+29,   
-
+    
                                                  -7.4229119E+36,   -1.19216618E+17,  
                                                  -1.76541143E+10,   1.06367558E+38,   
                                                   9.62853863E+24,  -1.02125985E-17  ];
-                                                  
+    
     // 2x3x1
     b : ARRAY[1..2,4..6,6..6] OF REAL :=  [       4.10516757E-36,        
                                                         666455872,  
                                                   -6.32274414E-23,
-   
+    
                                                   2.51930489E-20,      
                                                      -13.6131887,   
                                                   6.56142373E+29 ]; 
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array3d_DifferInSize_D3');
 
@@ -1216,9 +1269,10 @@ TEST_FINISHED();]]></ST>
     <Method Name="Test_REAL_Array3d_Equals" Id="{ac6e988d-1d5a-4b2f-9434-494cd25e9d00}">
       <Declaration><![CDATA[METHOD PRIVATE Test_REAL_Array3d_Equals
 VAR
-    a : ARRAY[-5..-4,-1..0,0..1] OF REAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6, 560344.0005];
-    b : ARRAY[1..2,4..5,6..7] OF REAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001, 560344.0006];
-END_VAR]]></Declaration>
+    a : ARRAY[-5..-4, -1..0, 0..1] OF REAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6, 560344.0005];
+    b : ARRAY[1..2, 4..5, 6..7] OF REAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001, 560344.0006];
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Array3d_Equals');
 
@@ -1235,7 +1289,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[0..0] OF SINT := [-128];
     b : ARRAY[0..0] OF SINT := [127];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_SINT_Array_DifferInContent');
 
@@ -1251,7 +1306,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[0..0] OF SINT := [-128];
     b : ARRAY[0..1] OF SINT := [-128, 127];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_SINT_Array_DifferInSize');
 
@@ -1267,7 +1323,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     b : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_SINT_Array_Equals');
 
@@ -1283,7 +1340,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-5..-4] OF UDINT := [4294967295, 5];
     b : ARRAY[0..1] OF UDINT := [4294967295, 4];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_UDINT_Array_DifferInContent');
 
@@ -1299,7 +1357,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[-5..-4] OF UDINT := [4294967295, 0];
     b : ARRAY[0..2] OF UDINT := [4294967295, 0, 5000];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_UDINT_Array_DifferInSize');
 
@@ -1315,7 +1374,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[1..3] OF UDINT := [0, 4294967295, 5000];
     b : ARRAY[1..3] OF UDINT := [0, 4294967295, 5000];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_UDINT_Array_Equals');
 
@@ -1331,7 +1391,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[0..3] OF UINT := [0, 4, 8, 99];
     b : ARRAY[0..3] OF UINT := [0, 4, 8, 12];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_UINT_Array_DifferInContent');
 
@@ -1347,7 +1408,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[0..2] OF UINT := [0, 4, 8];
     b : ARRAY[0..3] OF UINT := [0, 4, 8, 12];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_UINT_Array_DifferInSize');
 
@@ -1363,7 +1425,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[0..4] OF UINT := [0, 65535, 2000, 34123, 59];
     b : ARRAY[0..4] OF UINT := [0, 65535, 2000, 34123, 59];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_UINT_Array_Equals');
 
@@ -1379,7 +1442,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[0..1] OF ULINT := [3_213_000_444_000, 9_400_000_000_000];
     b : ARRAY[0..1] OF ULINT := [3_213_000_444_000, 18_446_744_073_709_551_615];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ULINT_Array_DifferInContent');
 
@@ -1395,7 +1459,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[0..1] OF ULINT := [0, 9_400_000_000_000];
     b : ARRAY[0..0] OF ULINT := [0];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ULINT_Array_DifferInSize');
 
@@ -1411,7 +1476,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[0..3] OF ULINT := [0, 18_446_744_073_709_551_615, 9_400_000_000_000, 3_213_000_444_000];
     b : ARRAY[0..3] OF ULINT := [0, 18_446_744_073_709_551_615, 9_400_000_000_000, 3_213_000_444_000];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ULINT_Array_Equals');
 
@@ -1425,9 +1491,10 @@ TEST_FINISHED();]]></ST>
     <Method Name="Test_USINT_Array_DifferInContent" Id="{a21148d1-d45d-4070-b3a5-fadc62daa9f6}">
       <Declaration><![CDATA[METHOD PRIVATE Test_USINT_Array_DifferInContent
 VAR
-    a : ARRAY[0..10] OF USINT := [0,1,2,3,6(4),5];
-    b : ARRAY[0..10] OF USINT := [0,1,2,3,6(5),6];
-END_VAR]]></Declaration>
+    a : ARRAY[0..10] OF USINT := [0, 1, 2, 3, 6(4), 5];
+    b : ARRAY[0..10] OF USINT := [0, 1, 2, 3, 6(5), 6];
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_USINT_Array_DifferInContent');
 
@@ -1443,7 +1510,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[0..100] OF USINT := [101(42)];
     b : ARRAY[0..70] OF USINT := [71(42)];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_USINT_Array_DifferInSize');
 
@@ -1459,7 +1527,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[0..100] OF USINT := [42, 100(33)];
     b : ARRAY[0..100] OF USINT := [42, 100(33)];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_USINT_Array_Equals');
 
@@ -1475,7 +1544,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[1..7] OF WORD := [16#2323, 16#876A, 16#4CD4, 16#F3DC, 16#BBBB, 16#FFFF, 16#1133];
     b : ARRAY[1..7] OF WORD := [16#2323, 16#876A, 16#4CD4, 16#F3DC, 16#BBBB, 16#FFFF, 16#1122];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WORD_Array_DifferInContent');
 
@@ -1491,7 +1561,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[1..5] OF WORD := [16#0000, 16#3333, 16#5555, 16#7777, 16#BBBB];
     b : ARRAY[1..7] OF WORD := [16#0000, 16#3333, 16#5555, 16#7777, 16#BBBB, 16#FFFF, 16#1122];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WORD_Array_DifferInSize');
 
@@ -1507,7 +1578,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ARRAY[1..5] OF WORD := [16#AAAA, 16#BBBB, 16#CCCC, 16#DDDD, 16#EEEE];
     b : ARRAY[1..5] OF WORD := [16#AAAA, 16#BBBB, 16#CCCC, 16#DDDD, 16#EEEE];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WORD_Array_Equals');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_AssertEveryFailedTestTwice.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_AssertEveryFailedTestTwice.TcPOU
@@ -8,7 +8,8 @@
 FUNCTION_BLOCK FB_AssertEveryFailedTestTwice EXTENDS TcUnit.FB_TestSuite
 VAR
     AssertCount : USINT := 0;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[TwiceAssertCall();]]></ST>
     </Implementation>
@@ -17,73 +18,74 @@ END_VAR]]></Declaration>
 VAR
     aANY : INT := 55;
     bANY : INT := 77;
-
+    
     aBOOL : BOOL := TRUE;
     bBOOL : BOOL := FALSE;
-
+    
     aBYTE : BYTE := 16#AB;
     bBYTE : BYTE := 16#BA;
-
+    
     aDATE : DATE := DATE#1996-05-06;
     bDATE : DATE := DATE#2019-01-20;
-
+    
     aDATE_AND_TIME : DATE_AND_TIME := DATE_AND_TIME#1996-05-06-15:36:30;
     bDATE_AND_TIME : DATE_AND_TIME := DATE_AND_TIME#1972-03-29-00:00:00;
-
+    
     aDINT : DINT := 4444;
     bDINT : DINT := 3333;
-
+    
     aDWORD : DWORD := 16#AAAAAAAA;
     bDWORD : DWORD := 16#BBBBBBBB;
-
+    
     aINT : INT := 30000;
     bINT : INT := 32000;
-
+    
     aLINT : LINT := 50000;
     bLINT : LINT := 50001;
-
+    
     aLREAL : LREAL := 33.3;
     bLREAL : LREAL := 44.4;
-
+    
     aLTIME : LTIME := LTIME#213503D23H34M33S709MS551US615NS;
     bLTIME : LTIME := LTIME#1000D15H23M12S34MS2US44NS;
-
+    
     aLWORD : LWORD := 16#AAAAAAAAAAAAAAAA;
     bLWORD : LWORD := 16#BBBBBBBBBBBBBBBB;
-
+    
     aREAL : REAL := 44.4;
     bREAL : REAL := 22.2;
-
+    
     aSINT : SINT := 99;
     bSINT : SINT := 10;
-
+    
     aSTRING : STRING := 'Hello world';
     bSTRING : STRING := 'Hey there';
-
+    
     aUDINT : UDINT := 249494994;
     bUDINT : UDINT := 1223;
-
+    
     aUINT : UINT := 3444;
     bUINT : UINT := 3445;
-
+    
     aULINT : ULINT := 789234475;
     bULINT : ULINT := 34523327234;
-
+    
     aUSINT : USINT := 34;
     bUSINT : USINT := 36;
-
+    
     aTIME : TIME := T#12H34M15S10MS;
     bTIME : TIME := T#11H34M13S244MS;
-
+    
     aTIME_OF_DAY : TIME_OF_DAY := TIME_OF_DAY#15:36:30.123;
     bTIME_OF_DAY : TIME_OF_DAY := TIME_OF_DAY#06:21:11.492;
-
+    
     aWORD : WORD := 16#ABCD;
     bWORD : WORD := 16#89EF;
-
-	aWSTRING : WSTRING := "åäöĦ";
+    
+    aWSTRING : WSTRING := "åäöĦ";
     bWSTRING : WSTRING := "åäöŅ";
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('TwiceAssertCall');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_AssertEveryFailedTestTwiceArrayVersion.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_AssertEveryFailedTestTwiceArrayVersion.TcPOU
@@ -9,7 +9,8 @@
 FUNCTION_BLOCK FB_AssertEveryFailedTestTwiceArrayVersion EXTENDS TcUnit.FB_TestSuite
 VAR
     AssertCount : USINT := 0;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[TwiceAssertCall_Arrays();]]></ST>
     </Implementation>
@@ -18,58 +19,58 @@ END_VAR]]></Declaration>
 VAR
     aBOOL : ARRAY[0..5] OF BOOL := [TRUE, TRUE, FALSE, TRUE, FALSE, TRUE];
     bBOOL : ARRAY[0..5] OF BOOL := [TRUE, TRUE, TRUE, TRUE, FALSE, FALSE];
-
+    
     aBYTE : ARRAY[0..3] OF BYTE := [16#AB, 16#AA, 16#BB, 16#89];
     bBYTE : ARRAY[0..3] OF BYTE := [16#AB, 16#CD, 16#BB, 16#89];
-
+    
     aDINT : ARRAY[3..5] OF DINT := [-4746, -2147483645, 0];
     bDINT : ARRAY[3..5] OF DINT := [-4746, -2147483641, 0];
-
+    
     aDWORD : ARRAY[-2..1] OF DWORD := [16#6789ABCD, 16#EFAA2346, 16#ABABABAB, 16#EEEEEEEE];
     bDWORD : ARRAY[-2..1] OF DWORD := [16#6789ABCD, 16#EF012345, 16#ABABABAB, 16#EEEEEEEE];
-
+    
     aINT : ARRAY[-8..-6] OF INT := [42, -23, -32768];
     bINT : ARRAY[1..3] OF INT := [42, 24, -32768];
-
+    
     aLINT : ARRAY[-1..1] OF LINT := [9_223_372_036_854_775_807, -9_223_372_036_853_775_808, 55];
     bLINT : ARRAY[4..6] OF LINT := [9_223_372_036_854_775_807, -9_223_372_036_854_775_808, 55];
-
+    
     aLREAL : ARRAY[-2..1] OF LREAL := [3.55, 7.88, 2.44];
     bLREAL : ARRAY[-1..2] OF LREAL := [3.56, 7.99, 2.44];
-
+    
     aLREAL2d : ARRAY[0..1, 0..1] OF LREAL := [4.44, 5.75, 6.96, 7.77];
     bLREAL2d : ARRAY[0..1, 0..1] OF LREAL := [4.45, 5.75, 6.68, 7.77];
-
+    
     aLREAL3d : ARRAY[0..1, 0..1, 0..1] OF LREAL := [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     bLREAL3d : ARRAY[0..1, 0..1, 0..1] OF LREAL := [1.0, 2.0, 3.0, 4.0, 5.0, 6.4, 7.0, 8.0];
-
+    
     aLWORD : ARRAY[1..1] OF LWORD := [16#EDCBA09876543210];
     bLWORD : ARRAY[1..1] OF LWORD := [16#01234567890ABCDE];
-
+    
     aREAL : ARRAY[0..2] OF REAL := [6.55000001, 3.54, 2.44001];
     bREAL : ARRAY[0..2] OF REAL := [6.55, 3.54, 2.44003];
-
+    
     aREAL2d : ARRAY[0..1, 0..1] OF REAL := [4.45, 5.75, 6.960001, 7.7701];
     bREAL2d : ARRAY[0..1, 0..1] OF REAL := [4.45, 5.75, 6.960002, 7.7703];
-
+    
     aREAL3d : ARRAY[0..1, 0..1, 0..1] OF REAL := [1.0, 2.0, 3.0, 4.01, 5.0, 6.0, 7.0, 8.0];
     bREAL3d : ARRAY[0..1, 0..1, 0..1] OF REAL := [1.0, 2.0, 3.0, 4.021, 5.0, 6.0, 7.0, 8.0];
-
+    
     aSINT : ARRAY[0..0] OF SINT := [-128];
     bSINT : ARRAY[0..0] OF SINT := [127];
-
+    
     aUDINT : ARRAY[-5..-4] OF UDINT := [4294967295, 5];
     bUDINT : ARRAY[0..1] OF UDINT := [4294967295, 4];
-
+    
     aUINT : ARRAY[0..3] OF UINT := [0, 4, 8, 99];
     bUINT : ARRAY[0..3] OF UINT := [0, 4, 8, 12];
-
+    
     aULINT : ARRAY[0..1] OF ULINT := [3_213_000_444_000, 9_400_000_000_000];
     bULINT : ARRAY[0..1] OF ULINT := [3_213_000_444_000, 18_446_744_073_709_551_615];
-
-    aUSINT : ARRAY[0..10] OF USINT := [0,1,2,3,6(4),5];
-    bUSINT : ARRAY[0..10] OF USINT := [0,1,2,3,6(5),6];
-
+    
+    aUSINT : ARRAY[0..10] OF USINT := [0, 1, 2, 3, 6(4), 5];
+    bUSINT : ARRAY[0..10] OF USINT := [0, 1, 2, 3, 6(5), 6];
+    
     aWORD : ARRAY[1..7] OF WORD := [16#2323, 16#876A, 16#4CD4, 16#F3DC, 16#BBBB, 16#FFFF, 16#1133];
     bWORD : ARRAY[1..7] OF WORD := [16#2323, 16#876A, 16#4CD4, 16#F3DC, 16#BBBB, 16#FFFF, 16#1122];
 END_VAR

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_AssertTrueFalse.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_AssertTrueFalse.TcPOU
@@ -6,7 +6,8 @@
     by making sure that every assert-method (assert_true & assert_false) does both one failing and one successful
     assert.
 *)
-FUNCTION_BLOCK FB_AssertTrueFalse EXTENDS TcUnit.FB_TestSuite]]></Declaration>
+FUNCTION_BLOCK FB_AssertTrueFalse EXTENDS TcUnit.FB_TestSuite
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[AssertThatINTsAreEqual();
 AssertThatINTsAreNotEqual();

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_CheckIfSpecificTestIsFinished.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_CheckIfSpecificTestIsFinished.TcPOU
@@ -4,12 +4,14 @@
     <Declaration><![CDATA[(*
     Verifies that the function IS_TEST_FINISHED('Name') works as intended.
 *)
-FUNCTION_BLOCK FB_CheckIfSpecificTestIsFinished EXTENDS TcUnit.FB_TestSuite]]></Declaration>
+FUNCTION_BLOCK FB_CheckIfSpecificTestIsFinished EXTENDS TcUnit.FB_TestSuite
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[CheckBeforeAndAfterFinishing();]]></ST>
     </Implementation>
     <Method Name="CheckBeforeAndAfterFinishing" Id="{bc4e3608-724f-4d4e-ad3f-c0950dd8383e}">
-      <Declaration><![CDATA[METHOD CheckBeforeAndAfterFinishing]]></Declaration>
+      <Declaration><![CDATA[METHOD CheckBeforeAndAfterFinishing
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('CheckBeforeAndAfterFinishing');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_CreateDisabledTest.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_CreateDisabledTest.TcPOU
@@ -5,7 +5,8 @@
     This testsuite runs two tests. One that is enabled (and that is supposed to fail), and one that is disabled (and
     even though it also is failing is not supposed to run).
 *)
-FUNCTION_BLOCK FB_CreateDisabledTest EXTENDS TcUnit.FB_TestSuite]]></Declaration>
+FUNCTION_BLOCK FB_CreateDisabledTest EXTENDS TcUnit.FB_TestSuite
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[TestEnabled();
 TestDisabled();]]></ST>

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_CreateFourTestsWithSameName.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_CreateFourTestsWithSameName.TcPOU
@@ -5,7 +5,8 @@
     This testsuite creates four tests in the same testsuite with the same name. Every test in a testsuite should have
     an unique name. Every assert should be ignored if a duplicate test is being run.
 *)
-FUNCTION_BLOCK FB_CreateFourTestsWithSameName EXTENDS TcUnit.FB_TestSuite]]></Declaration>
+FUNCTION_BLOCK FB_CreateFourTestsWithSameName EXTENDS TcUnit.FB_TestSuite
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[TestOne();
 TestOne_Again();

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_EmptyTestSuite.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_EmptyTestSuite.TcPOU
@@ -4,8 +4,7 @@
     <Declaration><![CDATA[(* This is an empty testsuite with no test cases, so that we can verify that the system still prints the
    test results. *)
 FUNCTION_BLOCK FB_EmptyTestSuite EXTENDS TcUnit.FB_TestSuite
-VAR
-END_VAR]]></Declaration>
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_ExtendedTestInformation.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_ExtendedTestInformation.TcPOU
@@ -4,7 +4,8 @@
     <Declaration><![CDATA[(* This test suite makes sure to create different variants of tests that will produce various extended logs, i.e. the
    ADS-logs that provide information on how many tests have finished/are successful within the test suites.
    This test suite needs to be instantiated as the second test suite in the order in order to get the ID=1 as identity. *)
-FUNCTION_BLOCK FB_ExtendedTestInformation EXTENDS TcUnit.FB_TestSuite]]></Declaration>
+FUNCTION_BLOCK FB_ExtendedTestInformation EXTENDS TcUnit.FB_TestSuite
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Test_ExtendedTestInformation_BOOL_AssertFailed();
 Test_ExtendedTestInformation_BOOL_AssertSuccess();
@@ -17,7 +18,8 @@ Test_ExtendedTestInformation_LINT_AssertSuccess();]]></ST>
 VAR
     a : BOOL := TRUE;
     b : BOOL := FALSE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ExtendedTestInformation_BOOL_AssertFailed');
 
@@ -33,7 +35,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : BOOL := TRUE;
     b : BOOL := TRUE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ExtendedTestInformation_BOOL_AssertSuccess');
 
@@ -51,7 +54,8 @@ VAR
     b : BYTE := 16#CD;
     c : BYTE := 16#EF;
     d : BYTE := 16#01;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ExtendedTestInformation_BYTE_TwoFailedAsserts');
 
@@ -71,7 +75,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LINT := -451416345;
     b : LINT := 589532453;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ExtendedTestInformation_LINT_AssertFailed');
 
@@ -87,7 +92,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LINT := -123456789;
     b : LINT := -123456789;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ExtendedTestInformation_LINT_AssertSuccess');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_MultipleAssertWithSameParametersInDifferentCyclesAndInSameTest.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_MultipleAssertWithSameParametersInDifferentCyclesAndInSameTest.TcPOU
@@ -11,10 +11,11 @@
 *)
 FUNCTION_BLOCK FB_MultipleAssertWithSameParametersInDifferentCyclesAndInSameTest EXTENDS TcUnit.FB_TestSuite
 VAR
-    TimerAgain : Tc2_Standard.TON := (PT := T#1S); // Timer to call "AssertSeveralTimesAgain"
-    TimerAgainAgain : Tc2_Standard.TON := (PT := T#5S); // Timer to call "AssertSeveralTimesAgainAgain"
+    TimerAgain : Tc2_Standard.TON := (PT:=T#1S); // Timer to call "AssertSeveralTimesAgain"
+    TimerAgainAgain : Tc2_Standard.TON := (PT:=T#5S); // Timer to call "AssertSeveralTimesAgainAgain"
     CalledAll : BOOL; // Indication of whether we've called all tests
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Assert_SeveralTimes();]]></ST>
     </Implementation>
@@ -23,31 +24,32 @@ END_VAR]]></Declaration>
 VAR
     a : DWORD := 16#12345678;
     b : DWORD := 16#90ABCDEF;
-
+    
     c : DWORD := 16#12345678;
     d : DWORD := 16#90ABCDEF;
-
+    
     e : DWORD := 16#12345678;
     f : DWORD := 16#90ABCDEF;
-
+    
     g : DWORD := 16#12345678;
     h : DWORD := 16#90ABCDEF;
-
+    
     i : DWORD := 16#12345678;
     j : DWORD := 16#90ABCDEF;
-
+    
     k : DWORD := 16#12345678;
     l : DWORD := 16#90ABCDEF;
-
+    
     m : DWORD := 16#12345678;
     n : DWORD := 16#90ABCDEF;
-
+    
     o : DWORD := 16#12345678;
     p : DWORD := 16#90ABCDEF;
-
+    
     q : DWORD := 16#12345678;
     rr : DWORD := 16#90ABCDEF;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Assert_SeveralTimes');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_MultipleAssertWithSameParametersInDifferentCyclesButWithDifferentTests.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_MultipleAssertWithSameParametersInDifferentCyclesButWithDifferentTests.TcPOU
@@ -11,10 +11,11 @@
 *)
 FUNCTION_BLOCK FB_MultipleAssertWithSameParametersInDifferentCyclesButWithDifferentTests EXTENDS TcUnit.FB_TestSuite
 VAR
-    TimerAgain : Tc2_Standard.TON := (PT := T#1S); // Timer to call "AssertSeveralTimesAgain"
-    TimerAgainAgain : Tc2_Standard.TON := (PT := T#5S); // Timer to call "AssertSeveralTimesAgainAgain"
+    TimerAgain : Tc2_Standard.TON := (PT:=T#1S); // Timer to call "AssertSeveralTimesAgain"
+    TimerAgainAgain : Tc2_Standard.TON := (PT:=T#5S); // Timer to call "AssertSeveralTimesAgainAgain"
     CalledAll : BOOL; // Indication of whether we've called all tests
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[TimerAgain(IN := TRUE);
 
@@ -35,13 +36,14 @@ END_IF]]></ST>
 VAR
     a : DWORD := 16#12345678;
     b : DWORD := 16#90ABCDEF;
-
+    
     c : DWORD := 16#12345678;
     d : DWORD := 16#90ABCDEF;
-
+    
     e : DWORD := 16#12345678;
     f : DWORD := 16#90ABCDEF;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Assert_SeveralTimes');
 
@@ -67,13 +69,14 @@ END_IF]]></ST>
 VAR
     a : DWORD := 16#12345678;
     b : DWORD := 16#90ABCDEF;
-
+    
     c : DWORD := 16#12345678;
     d : DWORD := 16#90ABCDEF;
-
+    
     e : DWORD := 16#12345678;
     f : DWORD := 16#90ABCDEF;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Assert_SeveralTimesAgain');
 
@@ -99,13 +102,14 @@ END_IF]]></ST>
 VAR
     a : DWORD := 16#12345678;
     b : DWORD := 16#90ABCDEF;
-
+    
     c : DWORD := 16#12345678;
     d : DWORD := 16#90ABCDEF;
-
+    
     e : DWORD := 16#12345678;
     f : DWORD := 16#90ABCDEF;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Assert_SeveralTimesAgainAgain');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_MultipleAssertWithSameParametersInSameCycleWithSameTest.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_MultipleAssertWithSameParametersInSameCycleWithSameTest.TcPOU
@@ -18,13 +18,14 @@ FUNCTION_BLOCK FB_MultipleAssertWithSameParametersInSameCycleWithSameTest EXTEND
 VAR
     a : DWORD := 16#12345678;
     b : DWORD := 16#90ABCDEF;
-
+    
     c : DWORD := 16#12345678;
     d : DWORD := 16#90ABCDEF;
-
+    
     e : DWORD := 16#12345678;
     f : DWORD := 16#90ABCDEF;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Assert_SeveralTimes');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_PrimitiveTypes.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_PrimitiveTypes.TcPOU
@@ -7,7 +7,8 @@
         1. One test that succeeds (Expected and actual are equal)
         2. One test that fails (Expected and actual are false).
 *)
-FUNCTION_BLOCK FB_PrimitiveTypes EXTENDS TcUnit.FB_TestSuite]]></Declaration>
+FUNCTION_BLOCK FB_PrimitiveTypes EXTENDS TcUnit.FB_TestSuite
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Test_ANY_Equals();
 Test_ANY_Differ_DataType();
@@ -61,7 +62,8 @@ Test_WSTRING_Differ();]]></ST>
 VAR
     a : INT := 5;
     b : UINT := 5;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_Differ_DataType');
 
@@ -77,7 +79,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : INT := 5;
     b : INT := 5;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ANY_Equals');
 
@@ -93,7 +96,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : BOOL := TRUE;
     b : BOOL := FALSE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BOOL_Differ');
 
@@ -109,7 +113,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : BOOL := TRUE;
     b : BOOL := TRUE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BOOL_Equals');
 
@@ -125,7 +130,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : BYTE := 16#AB;
     b : BYTE := 16#CD;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BYTE_Differ');
 
@@ -141,7 +147,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : BYTE := 16#CD;
     b : BYTE := 16#CD;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BYTE_Equals');
 
@@ -156,7 +163,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DATE_AND_TIME := DATE_AND_TIME#1996-05-06-15:36:30;
     b : DATE_AND_TIME := DATE_AND_TIME#1972-03-29-00:00:00;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DATE_AND_TIME_Differ');
 
@@ -172,7 +180,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DATE_AND_TIME := DATE_AND_TIME#2019-01-20-13:54:30;
     b : DATE_AND_TIME := DATE_AND_TIME#2019-01-20-13:54:30;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DATE_AND_TIME_Equals');
 
@@ -188,7 +197,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DATE := DATE#1996-05-06;
     b : DATE := DATE#2019-01-20;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DATE_Differ');
 
@@ -204,7 +214,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DATE := DATE#1996-05-06;
     b : DATE := DATE#1996-05-06;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DATE_Equals');
 
@@ -220,7 +231,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DINT := -55555;
     b : DINT := 70000;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DINT_Differ');
 
@@ -236,7 +248,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DINT := -80000;
     b : DINT := -80000;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DINT_Equals');
 
@@ -252,7 +265,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DWORD := 16#12345678;
     b : DWORD := 16#90ABCDEF;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DWORD_Differ');
 
@@ -268,7 +282,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : DWORD := 16#7890ABCD;
     b : DWORD := 16#7890ABCD;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_DWORD_Equals');
 
@@ -284,7 +299,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : INT := -32000;
     b : INT := 15423;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_INT_Differ');
 
@@ -300,7 +316,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : INT := -12345;
     b : INT := -12345;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_INT_Equals');
 
@@ -316,7 +333,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LINT := -451416345;
     b : LINT := 589532453;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LINT_Differ');
 
@@ -332,7 +350,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LINT := -123456789;
     b : LINT := -123456789;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LINT_Equals');
 
@@ -348,7 +367,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LREAL := 1234567.89;
     b : LREAL := 1234567.76;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Differ');
 
@@ -365,7 +385,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LREAL := 1234567.89;
     b : LREAL := 1234567.76;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LREAL_Equals');
 
@@ -382,7 +403,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LTIME := LTIME#213503D23H34M33S709MS551US615NS;
     b : LTIME := LTIME#1000D15H23M12S34MS2US44NS;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LTIME_Differ');
 
@@ -398,7 +420,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LTIME := LTIME#213503D23H34M33S709MS551US615NS;
     b : LTIME := LTIME#213503D23H34M33S709MS551US615NS;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LTIME_Equals');
 
@@ -414,7 +437,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LWORD := 16#0123656789ABCBEC;
     b : LWORD := 16#0123256789ABCAEE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LWORD_Differ');
 
@@ -430,7 +454,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : LWORD := 16#0123456789ABCDEF;
     b : LWORD := 16#0123456789ABCDEF;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LWORD_Equals');
 
@@ -446,7 +471,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : REAL := 1234.5;
     b : REAL := 1234.4;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Differ');
 
@@ -463,7 +489,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : REAL := 1234.5;
     b : REAL := 1234.4;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_REAL_Equals');
 
@@ -480,7 +507,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : SINT := 127;
     b : SINT := -30;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_SINT_Differ');
 
@@ -496,7 +524,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : SINT := -128;
     b : SINT := -128;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_SINT_Equals');
 
@@ -512,7 +541,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : STRING := 'This is a string';
     b : STRING := 'This is another string';
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_STRING_Differ');
 
@@ -528,7 +558,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : STRING := 'Hello there';
     b : STRING := 'Hello there';
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_STRING_Equals');
 
@@ -544,7 +575,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : TIME := T#12H34M15S10MS;
     b : TIME := T#11H34M13S244MS;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_TIME_Differ');
 
@@ -560,7 +592,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : TIME := T#11H34M13S244MS;
     b : TIME := T#11H34M13S244MS;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_TIME_Equals');
 
@@ -576,7 +609,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : TIME_OF_DAY := TIME_OF_DAY#15:36:30.123;
     b : TIME_OF_DAY := TIME_OF_DAY#06:21:11.492;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_TIME_OF_DAY_Differ');
 
@@ -592,7 +626,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : TIME_OF_DAY := TIME_OF_DAY#06:21:11.492;
     b : TIME_OF_DAY := TIME_OF_DAY#06:21:11.492;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_TIME_OF_DAY_Equals');
 
@@ -608,7 +643,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : UDINT := 34124214;
     b : UDINT := 52343244;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_UDINT_Differ');
 
@@ -624,7 +660,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : UDINT := 21845123;
     b : UDINT := 21845123;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_UDINT_Equals');
 
@@ -640,7 +677,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : UINT := 64322;
     b : UINT := 32312;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_UINT_Differ');
 
@@ -656,7 +694,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : UINT := 65535;
     b : UINT := 65535;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_UINT_Equals');
 
@@ -672,7 +711,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ULINT := 10000;
     b : ULINT := 53685437234;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ULINT_Differ');
 
@@ -688,7 +728,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : ULINT := 45683838383;
     b : ULINT := 45683838383;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ULINT_Equals');
 
@@ -704,7 +745,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : USINT := 3;
     b : USINT := 7;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_USINT_Differ');
 
@@ -720,7 +762,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : USINT := 5;
     b : USINT := 5;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_USINT_Equals');
 
@@ -736,7 +779,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : WORD := 16#EF01;
     b : WORD := 16#2345;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WORD_Differ');
 
@@ -752,7 +796,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : WORD := 16#ABCD;
     b : WORD := 16#ABCD;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WORD_Equals');
 
@@ -768,7 +813,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : WSTRING := "äö";
     b : WSTRING := "æåŅ";
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WSTRING_Differ');
 
@@ -784,7 +830,8 @@ TEST_FINISHED();]]></ST>
 VAR
     a : WSTRING := "ŏŜŢ";
     b : WSTRING := "ŏŜŢ";
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WSTRING_Equals');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_SkipAssertionsWhenFinished.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_SkipAssertionsWhenFinished.TcPOU
@@ -12,9 +12,10 @@
 *)
 FUNCTION_BLOCK FB_SkipAssertionsWhenFinished EXTENDS TcUnit.FB_TestSuite
 VAR
-    ShortTimer : Tc2_Standard.TON := (PT := T#200MS);
-    LongTimer : Tc2_Standard.TON := (PT := T#1S);
-END_VAR]]></Declaration>
+    ShortTimer : Tc2_Standard.TON := (PT:=T#200MS);
+    LongTimer : Tc2_Standard.TON := (PT:=T#1S);
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Test_LongTest(ADR(LongTimer));
 Test_ShortTest(ADR(ShortTimer));
@@ -25,7 +26,8 @@ Test_AssertImmediatelyAfterFinished();]]></ST>
     Assertions called immediately after (and within the same cycle as) TEST_FINISHED should be
     ignored.
 *)
-METHOD Test_AssertImmediatelyAfterFinished]]></Declaration>
+METHOD Test_AssertImmediatelyAfterFinished
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_AssertImmediatelyAfterFinished');
 TEST_FINISHED();
@@ -37,7 +39,8 @@ AssertTrue(FALSE, 'This failing assertion should be skipped because the test is 
       <Declaration><![CDATA[METHOD Test_LongTest
 VAR_INPUT
     Timer : POINTER TO Tc2_Standard.TON;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_LongTest');
 
@@ -51,7 +54,8 @@ END_IF]]></ST>
       <Declaration><![CDATA[METHOD Test_ShortTest
 VAR_INPUT
     Timer : POINTER TO Tc2_Standard.TON;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_ShortTest');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestFileControl.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestFileControl.TcPOU
@@ -4,7 +4,8 @@
     <Declaration><![CDATA[(*
     Contains tests that verify the FileControl function block methods
 *)
-FUNCTION_BLOCK FB_TestFileControl EXTENDS TcUnit.FB_TestSuite]]></Declaration>
+FUNCTION_BLOCK FB_TestFileControl EXTENDS TcUnit.FB_TestSuite
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Test_FileRead();
 Test_FileOpen();
@@ -19,7 +20,8 @@ VAR
     TestFile : STRING := 'Test_FileClose.txt';
     Mode : SysFile.ACCESS_MODE := SysFile.ACCESS_MODE.AM_APPEND_PLUS;
     Actual : SysFile.SysTypes.RTS_IEC_RESULT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_FileClose');
 
@@ -42,7 +44,8 @@ VAR
     TestFile : STRING := 'Test_FileDelete.txt';
     Mode : SysFile.ACCESS_MODE := SysFile.ACCESS_MODE.AM_APPEND_PLUS;
     Actual : SysFile.SysTypes.RTS_IEC_RESULT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_FileDelete');
 
@@ -64,7 +67,8 @@ VAR
     TestFile : STRING := 'Test_FileOpen.txt';
     Mode : SysFile.ACCESS_MODE := SysFile.ACCESS_MODE.AM_APPEND_PLUS;
     Actual : SysFile.SysTypes.RTS_IEC_RESULT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_FileOpen');
 
@@ -90,7 +94,8 @@ VAR
     FileSize : SysFile.SysTypes.RTS_IEC_SIZE;
     WriteContents : STRING(64) := '0KflxSh6C%ixPs8ReCPwFuJu)D$p*qfi66iTj&YKMdpq*EGBGiwgAsOs1s(dci';
     ReadContents : STRING(64);
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_FileRead');
 
@@ -119,7 +124,8 @@ VAR
     TestFile : STRING := 'Test_FileWrite.txt';
     Mode : SysFile.ACCESS_MODE := SysFile.ACCESS_MODE.AM_APPEND_PLUS;
     Actual : SysFile.SysTypes.RTS_IEC_RESULT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_FileWrite');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestFinishedNamed.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestFinishedNamed.TcPOU
@@ -4,8 +4,7 @@
     <Declaration><![CDATA[(* This function blocks tests the TEST_FINISHED_NAMED function by creating various tests
    and finishing them in steps *)
 FUNCTION_BLOCK FB_TestFinishedNamed EXTENDS TcUnit.FB_TestSuite
-VAR
-END_VAR]]></Declaration>
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestFinishedNamedDoesNotExist.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestFinishedNamedDoesNotExist.TcPOU
@@ -6,8 +6,7 @@
     produce an error message that says so. This error message should also only be printed once.
 *)
 FUNCTION_BLOCK FB_TestFinishedNamedDoesNotExist EXTENDS TcUnit.FB_TestSuite
-VAR
-END_VAR]]></Declaration>
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Test_FinishedNamed();]]></ST>
     </Implementation>
@@ -16,7 +15,8 @@ END_VAR]]></Declaration>
 VAR
     a : INT := 2;
     b : INT := 2;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_FinishedNamed');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestNumberOfAssertionsCalculation.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestNumberOfAssertionsCalculation.TcPOU
@@ -4,7 +4,8 @@
     <Declaration><![CDATA[(*
     This testsuite verifies that the amount of assertions for every testcase is correctly calculated
 *)
-FUNCTION_BLOCK FB_TestNumberOfAssertionsCalculation EXTENDS TcUnit.FB_TestSuite]]></Declaration>
+FUNCTION_BLOCK FB_TestNumberOfAssertionsCalculation EXTENDS TcUnit.FB_TestSuite
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[TestMixed33SuccessulAnd9FailedAssertions();
 TestWith43SuccessfulAssertions();
@@ -18,171 +19,172 @@ VAR
     // Successful
     aAny : INT := 5;
     bAny : INT := 5;
-
+    
     // Successful
     aBool : BOOL := TRUE;
     bBool : BOOL := TRUE;
-
+    
     // Failed
     aDint : ARRAY[2..7] OF DINT := [64, 98, 2147483647, -2147483648, 0, -63987538];
     bDint : ARRAY[1..5] OF DINT := [64, 98, 2147483647, -2147483648, 0];
-
+    
     // Failed
     aDword : ARRAY[2..3] OF DWORD := [16#6789ABCD, 16#EF012345];
     bDword : ARRAY[1..2] OF DWORD := [16#6789ABCD, 16#EF012343];
-
+    
     // Successful
     aInt : ARRAY[-5..1] OF INT := [64, 98, -32768, 32767, 5478, -378, 42];
     bInt : ARRAY[1..7] OF INT := [64, 98, -32768, 32767, 5478, -378, 42];
-
+    
     // Successful
     aLint : ARRAY[-1..0] OF LINT := [9_223_372_036_854_775_807, -9_223_372_036_854_775_808];
     bLint : ARRAY[4..5] OF LINT := [9_223_372_036_854_775_807, -9_223_372_036_854_775_808];
-
+    
     // Failed
     aLreal : LREAL := 1234564.89;
     bLreal : LREAL := 1234567.76;
-
+    
     // Failed
     aLtime : LTIME := LTIME#213503D23H33M33S709MS551US615NS;
     bLtime : LTIME := LTIME#213503D23H34M33S709MS551US615NS;
-
+    
     // Failed
     aLrealArray : ARRAY[-5..1] OF LREAL := [64.0, 97.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6];
     bLrealArray : ARRAY[1..7] OF LREAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001];
-
+    
     // Failed
-    aLreal2d : ARRAY[-5..-3,-1..0] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5];
-    bLreal2d : ARRAY[1..3,0..1] OF LREAL := [63.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003];
-
+    aLreal2d : ARRAY[-5..-3, -1..0] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5];
+    bLreal2d : ARRAY[1..3, 0..1] OF LREAL := [63.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003];
+    
     // Successful
     aLword : LWORD := 16#0123456789ABCDEF;
     bLword : LWORD := 16#0123456789ABCDEF;
-
+    
     // Successful
     aSint : SINT := -128;
     bSint : SINT := -128;
-
+    
     // Successful
     aUdint : ARRAY[1..3] OF UDINT := [0, 4294967295, 5000];
     bUdint : ARRAY[1..3] OF UDINT := [0, 4294967295, 5000];
-
+    
     // Successful
     aUint : ARRAY[0..4] OF UINT := [0, 65535, 2000, 34123, 59];
     bUint : ARRAY[0..4] OF UINT := [0, 65535, 2000, 34123, 59];
-
+    
     // Failed
     aUlint : ULINT := 45683838382;
     bUlint : ULINT := 45683838383;
-
+    
     // Failed
     aUsint : USINT := 4;
     bUsint : USINT := 5;
-
+    
     // Failed
     aWord : ARRAY[1..5] OF WORD := [16#AAAA, 16#BBBF, 16#CCCC, 16#DDDD, 16#EEEE];
     bWord : ARRAY[1..5] OF WORD := [16#AAAA, 16#BBBB, 16#CCCC, 16#DDDD, 16#EEEE];
-
+    
     // Successful
     aSintDummy1 : SINT := 1;
     bSintDummy1 : SINT := 1;
-
+    
     // Successful
     aSintDummy2 : SINT := 2;
     bSintDummy2 : SINT := 2;
-
+    
     // Successful
     aSintDummy3 : SINT := 3;
     bSintDummy3 : SINT := 3;
-
+    
     // Successful
     aSintDummy4 : SINT := 4;
     bSintDummy4 : SINT := 4;
-
+    
     // Successful
     aSintDummy5 : SINT := 5;
     bSintDummy5 : SINT := 5;
-
+    
     // Successful
     aSintDummy6 : SINT := 6;
     bSintDummy6 : SINT := 6;
-
+    
     // Successful
     aSintDummy7 : SINT := 7;
     bSintDummy7 : SINT := 7;
-
+    
     // Successful
     aSintDummy8 : SINT := 8;
     bSintDummy8 : SINT := 8;
-
+    
     // Successful
     aSintDummy9 : SINT := 9;
     bSintDummy9 : SINT := 9;
-
+    
     // Successful
     aSintDummy10 : SINT := 10;
     bSintDummy10 : SINT := 10;
-
+    
     // Successful
     aSintDummy11 : SINT := 11;
     bSintDummy11 : SINT := 11;
-
+    
     // Successful
     aSintDummy12 : SINT := 12;
     bSintDummy12 : SINT := 12;
-
+    
     // Successful
     aSintDummy13 : SINT := 13;
     bSintDummy13 : SINT := 13;
-
+    
     // Successful
     aSintDummy14 : SINT := 14;
     bSintDummy14 : SINT := 14;
-
+    
     // Successful
     aSintDummy15 : SINT := 15;
     bSintDummy15 : SINT := 15;
-
+    
     // Successful
     aSintDummy16 : SINT := 16;
     bSintDummy16 : SINT := 16;
-
+    
     // Successful
     aSintDummy17 : SINT := 17;
     bSintDummy17 : SINT := 17;
-
+    
     // Successful
     aSintDummy18 : SINT := 18;
     bSintDummy18 : SINT := 18;
-
+    
     // Successful
     aSintDummy19 : SINT := 19;
     bSintDummy19 : SINT := 19;
-
+    
     // Successful
     aSintDummy20 : SINT := 20;
     bSintDummy20 : SINT := 20;
-
+    
     // Successful
     aSintDummy21 : SINT := 21;
     bSintDummy21 : SINT := 21;
-
+    
     // Successful
     aSintDummy22 : SINT := 22;
     bSintDummy22 : SINT := 22;
-
+    
     // Successful
     aSintDummy23 : SINT := 23;
     bSintDummy23 : SINT := 23;
-
+    
     // Successful
     aSintDummy24 : SINT := 24;
     bSintDummy24 : SINT := 24;
-
+    
     // Successful
     aSintDummy25 : SINT := 25;
     bSintDummy25 : SINT := 25;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('TestMixed33SuccessulAnd9FailedAssertions');
 
@@ -365,134 +367,134 @@ TEST_FINISHED();]]></ST>
 VAR
     aAny : INT := 5;
     bAny : INT := 5;
-
+    
     aBool : BOOL := TRUE;
     bBool : BOOL := TRUE;
-
+    
     aByte : BYTE := 16#CD;
     bByte : BYTE := 16#CD;
-
+    
     aDateAndTime : DATE_AND_TIME := DATE_AND_TIME#2019-01-20-13:54:30;
     bDateAndTime : DATE_AND_TIME := DATE_AND_TIME#2019-01-20-13:54:30;
-
+    
     aDate : DATE := DATE#1996-05-06;
     bDate : DATE := DATE#1996-05-06;
-
+    
     aDint : DINT := -80000;
     bDint : DINT := -80000;
-
+    
     aDword : DWORD := 16#7890ABCD;
     bDword : DWORD := 16#7890ABCD;
-
-
+    
     aInt : INT := -12345;
     bInt : INT := -12345;
-
+    
     aLint : LINT := -123456789;
     bLint : LINT := -123456789;
-
+    
     aLreal : LREAL := 1234567.89;
     bLreal : LREAL := 1234567.76;
-
+    
     aLtime : LTIME := LTIME#213503D23H34M33S709MS551US615NS;
     bLtime : LTIME := LTIME#213503D23H34M33S709MS551US615NS;
-
+    
     aLword : LWORD := 16#0123456789ABCDEF;
     bLword : LWORD := 16#0123456789ABCDEF;
-
+    
     aReal : REAL := 1234.5;
     bReal : REAL := 1234.4;
-
+    
     aSint : SINT := -128;
     bSint : SINT := -128;
-
+    
     aString : STRING := 'Hello there';
     bString : STRING := 'Hello there';
-
+    
     aTime : TIME := T#11H34M13S244MS;
     bTime : TIME := T#11H34M13S244MS;
-
+    
     aTimeOfDay : TIME_OF_DAY := TIME_OF_DAY#06:21:11.492;
     bTimeOfDay : TIME_OF_DAY := TIME_OF_DAY#06:21:11.492;
-
+    
     aUdint : UDINT := 21845123;
     bUdint : UDINT := 21845123;
-
+    
     aUint : UINT := 65535;
     bUint : UINT := 65535;
-
+    
     aUlint : ULINT := 45683838383;
     bUlint : ULINT := 45683838383;
-
+    
     aUsint : USINT := 5;
     bUsint : USINT := 5;
-
+    
     aWord : WORD := 16#ABCD;
     bWord : WORD := 16#ABCD;
-
+    
     aSintDummy1 : SINT := 1;
     bSintDummy1 : SINT := 1;
-
+    
     aSintDummy2 : SINT := 2;
     bSintDummy2 : SINT := 2;
-
+    
     aSintDummy3 : SINT := 3;
     bSintDummy3 : SINT := 3;
-
+    
     aSintDummy4 : SINT := 4;
     bSintDummy4 : SINT := 4;
-
+    
     aSintDummy5 : SINT := 5;
     bSintDummy5 : SINT := 5;
-
+    
     aSintDummy6 : SINT := 6;
     bSintDummy6 : SINT := 6;
-
+    
     aSintDummy7 : SINT := 7;
     bSintDummy7 : SINT := 7;
-
+    
     aSintDummy8 : SINT := 8;
     bSintDummy8 : SINT := 8;
-
+    
     aSintDummy9 : SINT := 9;
     bSintDummy9 : SINT := 9;
-
+    
     aSintDummy10 : SINT := 10;
     bSintDummy10 : SINT := 10;
-
+    
     aSintDummy11 : SINT := 11;
     bSintDummy11 : SINT := 11;
-
+    
     aSintDummy12 : SINT := 12;
     bSintDummy12 : SINT := 12;
-
+    
     aSintDummy13 : SINT := 13;
     bSintDummy13 : SINT := 13;
-
+    
     aSintDummy14 : SINT := 14;
     bSintDummy14 : SINT := 14;
-
+    
     aSintDummy15 : SINT := 15;
     bSintDummy15 : SINT := 15;
-
+    
     aSintDummy16 : SINT := 16;
     bSintDummy16 : SINT := 16;
-
+    
     aSintDummy17 : SINT := 17;
     bSintDummy17 : SINT := 17;
-
+    
     aSintDummy18 : SINT := 18;
     bSintDummy18 : SINT := 18;
-
+    
     aSintDummy19 : SINT := 19;
     bSintDummy19 : SINT := 19;
-
+    
     aSintDummy20 : SINT := 20;
     bSintDummy20 : SINT := 20;
-
+    
     aSintDummy21 : SINT := 21;
     bSintDummy21 : SINT := 21;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('TestWith22SuccessfulAssertions');
 
@@ -678,136 +680,137 @@ TEST_FINISHED();]]></ST>
 VAR
     aAny : INT := 5;
     bAny : INT := 4;
-
+    
     aBool : BOOL := TRUE;
     bBool : BOOL := FALSE;
-
+    
     aBool2 : BOOL := FALSE;
     bBool2 : BOOL := TRUE;
-
+    
     aByte : BYTE := 16#AB;
     bByte : BYTE := 16#CD;
-
+    
     aDateAndTime : DATE_AND_TIME := DATE_AND_TIME#2018-01-20-13:54:30;
     bDateAndTime : DATE_AND_TIME := DATE_AND_TIME#2019-01-20-13:54:30;
-
+    
     aDate : DATE := DATE#1995-05-06;
     bDate : DATE := DATE#1996-05-06;
-
+    
     aDint : DINT := -80001;
     bDint : DINT := -80000;
-
+    
     aDword : DWORD := 16#7890ABDD;
     bDword : DWORD := 16#7890ABCD;
-
+    
     aInt : INT := -12344;
     bInt : INT := -12345;
-
+    
     aLint : LINT := -123456787;
     bLint : LINT := -123456789;
-
+    
     aLreal : LREAL := 1234564.89;
     bLreal : LREAL := 1234567.76;
-
+    
     aLtime : LTIME := LTIME#213503D23H33M33S709MS551US615NS;
     bLtime : LTIME := LTIME#213503D23H34M33S709MS551US615NS;
-
+    
     aLword : LWORD := 16#0123456789ABCDEE;
     bLword : LWORD := 16#0123456789ABCDEF;
-
+    
     aReal : REAL := 1232.5;
     bReal : REAL := 1234.4;
-
+    
     aSint : SINT := -123;
     bSint : SINT := -128;
-
+    
     aString : STRING := 'Hello there!';
     bString : STRING := 'Hello there';
-
+    
     aTime : TIME := T#11H34M13S241MS;
     bTime : TIME := T#11H34M13S244MS;
-
+    
     aTimeOfDay : TIME_OF_DAY := TIME_OF_DAY#06:21:10.492;
     bTimeOfDay : TIME_OF_DAY := TIME_OF_DAY#06:21:11.492;
-
+    
     aUdint : UDINT := 21845122;
     bUdint : UDINT := 21845123;
-
+    
     aUint : UINT := 65534;
     bUint : UINT := 65535;
-
+    
     aUlint : ULINT := 45683838382;
     bUlint : ULINT := 45683838383;
-
+    
     aUsint : USINT := 4;
     bUsint : USINT := 5;
-
+    
     aWord : WORD := 16#ABCE;
     bWord : WORD := 16#ABCD;
-
+    
     aSintDummy1 : SINT := 1;
     bSintDummy1 : SINT := 2;
-
+    
     aSintDummy2 : SINT := 3;
     bSintDummy2 : SINT := 4;
-
+    
     aSintDummy3 : SINT := 5;
     bSintDummy3 : SINT := 6;
-
+    
     aSintDummy4 : SINT := 7;
     bSintDummy4 : SINT := 8;
-
+    
     aSintDummy5 : SINT := 9;
     bSintDummy5 : SINT := 10;
-
+    
     aSintDummy6 : SINT := 11;
     bSintDummy6 : SINT := 12;
-
+    
     aSintDummy7 : SINT := 13;
     bSintDummy7 : SINT := 14;
-
+    
     aSintDummy8 : SINT := 15;
     bSintDummy8 : SINT := 16;
-
+    
     aSintDummy9 : SINT := 17;
     bSintDummy9 : SINT := 18;
-
+    
     aSintDummy10 : SINT := 19;
     bSintDummy10 : SINT := 20;
-
+    
     aSintDummy11 : SINT := 21;
     bSintDummy11 : SINT := 22;
-
+    
     aSintDummy12 : SINT := 23;
     bSintDummy12 : SINT := 24;
-
+    
     aSintDummy13 : SINT := 25;
     bSintDummy13 : SINT := 26;
-
+    
     aSintDummy14 : SINT := 27;
     bSintDummy14 : SINT := 28;
-
+    
     aSintDummy15 : SINT := 29;
     bSintDummy15 : SINT := 30;
-
+    
     aSintDummy16 : SINT := 31;
     bSintDummy16 : SINT := 32;
-
+    
     aSintDummy17 : SINT := 33;
     bSintDummy17 : SINT := 34;
-
+    
     aSintDummy18 : SINT := 35;
     bSintDummy18 : SINT := 36;
-
+    
     aSintDummy19 : SINT := 37;
     bSintDummy19 : SINT := 38;
-
+    
     aSintDummy20 : SINT := 39;
     bSintDummy20 : SINT := 40;
-
+    
     aSintDummy21 : SINT := 41;
     bSintDummy21 : SINT := 42;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('TestWith44FailedAssertions');
 
@@ -997,139 +1000,140 @@ TEST_FINISHED();]]></ST>
 VAR
     aBool : ARRAY[1..5] OF BOOL := [TRUE, FALSE, TRUE, FALSE, TRUE];
     bBool : ARRAY[1..5] OF BOOL := [TRUE, FALSE, TRUE, FALSE, TRUE];
-
+    
     aByte : ARRAY[1..3] OF BYTE := [16#FD, 16#34, 16#9E];
     bByte : ARRAY[1..3] OF BYTE := [16#FD, 16#34, 16#9E];
-
+    
     aDint : ARRAY[2..7] OF DINT := [64, 98, 2147483647, -2147483648, 0, -63987538];
     bDint : ARRAY[2..7] OF DINT := [64, 98, 2147483647, -2147483648, 0, -63987538];
-
+    
     aDword : ARRAY[2..3] OF DWORD := [16#6789ABCD, 16#EF012345];
     bDword : ARRAY[1..2] OF DWORD := [16#6789ABCD, 16#EF012345];
-
+    
     aInt : ARRAY[-5..1] OF INT := [64, 98, -32768, 32767, 5478, -378, 42];
     bInt : ARRAY[1..7] OF INT := [64, 98, -32768, 32767, 5478, -378, 42];
-
+    
     aLint : ARRAY[-1..0] OF LINT := [9_223_372_036_854_775_807, -9_223_372_036_854_775_808];
     bLint : ARRAY[4..5] OF LINT := [9_223_372_036_854_775_807, -9_223_372_036_854_775_808];
-
+    
     aLreal : ARRAY[-5..1] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6];
     bLreal : ARRAY[1..7] OF LREAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001];
-
-    aLreal2d : ARRAY[-5..-3,-1..0] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5];
-    bLreal2d : ARRAY[1..3,0..1] OF LREAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003];
-
-    aLreal3d : ARRAY[-5..-4,-1..0,0..1] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6, 560344.0005];
-    bLreal3d : ARRAY[1..2,4..5,6..7] OF LREAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001, 560344.0006];
-
+    
+    aLreal2d : ARRAY[-5..-3, -1..0] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5];
+    bLreal2d : ARRAY[1..3, 0..1] OF LREAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003];
+    
+    aLreal3d : ARRAY[-5..-4, -1..0, 0..1] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6, 560344.0005];
+    bLreal3d : ARRAY[1..2, 4..5, 6..7] OF LREAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001, 560344.0006];
+    
     aLword : ARRAY[1..2] OF LWORD := [16#01234567890ABCDE, 16#EDCBA09876543210];
     bLword : ARRAY[1..2] OF LWORD := [16#01234567890ABCDE, 16#EDCBA09876543210];
-
+    
     aReal : ARRAY[-5..1] OF REAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6];
     bReal : ARRAY[1..7] OF REAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001];
-
-    aReal2d : ARRAY[-5..-3,-1..0] OF REAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5];
-    bReal2d : ARRAY[1..3,0..1] OF REAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003];
-
-    aReal3d : ARRAY[-5..-4,-1..0,0..1] OF REAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6, 560344.0005];
-    bReal3d : ARRAY[1..2,4..5,6..7] OF REAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001, 560344.0006];
-
+    
+    aReal2d : ARRAY[-5..-3, -1..0] OF REAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5];
+    bReal2d : ARRAY[1..3, 0..1] OF REAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003];
+    
+    aReal3d : ARRAY[-5..-4, -1..0, 0..1] OF REAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6, 560344.0005];
+    bReal3d : ARRAY[1..2, 4..5, 6..7] OF REAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001, 560344.0006];
+    
     aSint : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSint : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aUdint : ARRAY[1..3] OF UDINT := [0, 4294967295, 5000];
     bUdint : ARRAY[1..3] OF UDINT := [0, 4294967295, 5000];
-
+    
     aUint : ARRAY[0..4] OF UINT := [0, 65535, 2000, 34123, 59];
     bUint : ARRAY[0..4] OF UINT := [0, 65535, 2000, 34123, 59];
-
+    
     aUlint : ARRAY[0..3] OF ULINT := [0, 18_446_744_073_709_551_615, 9_400_000_000_000, 3_213_000_444_000];
     bUlint : ARRAY[0..3] OF ULINT := [0, 18_446_744_073_709_551_615, 9_400_000_000_000, 3_213_000_444_000];
-
+    
     aUsint : ARRAY[0..100] OF USINT := [42, 100(33)];
     bUsint : ARRAY[0..100] OF USINT := [42, 100(33)];
-
+    
     aWord : ARRAY[1..5] OF WORD := [16#AAAA, 16#BBBB, 16#CCCC, 16#DDDD, 16#EEEE];
     bWord : ARRAY[1..5] OF WORD := [16#AAAA, 16#BBBB, 16#CCCC, 16#DDDD, 16#EEEE];
-
+    
     aSintDummy1 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy1 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy2 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy2 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy3 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy3 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy4 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy4 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy5 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy5 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy6 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy6 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy7 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy7 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy8 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy8 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy9 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy9 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy10 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy10 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy11 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy11 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy12 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy12 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy13 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy13 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy14 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy14 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy15 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy15 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy16 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy16 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy17 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy17 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy18 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy18 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy19 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy19 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy20 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy20 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy21 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy21 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy22 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy22 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy23 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy23 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy24 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy24 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy25 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy25 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aSintDummy26 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy26 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('TestWith45SuccessfulArrayAssertions');
 
@@ -1327,143 +1331,143 @@ TEST_FINISHED();]]></ST>
 VAR
     aBool : ARRAY[1..4] OF BOOL := [TRUE, FALSE, TRUE, FALSE];
     bBool : ARRAY[1..5] OF BOOL := [TRUE, FALSE, TRUE, FALSE, TRUE];
-
+    
     aByte : ARRAY[1..3] OF BYTE := [16#FD, 16#34, 16#9F];
     bByte : ARRAY[1..3] OF BYTE := [16#FD, 16#34, 16#9E];
-
+    
     aDint : ARRAY[2..7] OF DINT := [64, 98, 2147483647, -2147483648, 0, -63987538];
     bDint : ARRAY[1..5] OF DINT := [64, 98, 2147483647, -2147483648, 0];
-
+    
     aDword : ARRAY[2..3] OF DWORD := [16#6789ABCD, 16#EF012345];
     bDword : ARRAY[1..2] OF DWORD := [16#6789ABCD, 16#EF012343];
-
+    
     aDword2 : ARRAY[1..2] OF DWORD := [16#6789ABCD, 16#EF012343];
     bDword2 : ARRAY[2..3] OF DWORD := [16#6789ABCD, 16#EF012345];
-
+    
     aInt : ARRAY[-5..1] OF INT := [64, 95, -32768, 32767, 5478, -378, 42];
     bInt : ARRAY[1..7] OF INT := [64, 98, -32768, 32767, 5478, -378, 42];
-
+    
     aLint : ARRAY[-1..-1] OF LINT := [9_223_372_036_854_775_807];
     bLint : ARRAY[4..5] OF LINT := [9_223_372_036_854_775_807, -9_223_372_036_854_775_808];
-
+    
     aLreal : ARRAY[-5..1] OF LREAL := [64.0, 97.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6];
     bLreal : ARRAY[1..7] OF LREAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001];
-
-    aLreal2d : ARRAY[-5..-3,-1..0] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5];
-    bLreal2d : ARRAY[1..3,0..1] OF LREAL := [63.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003];
-
-    aLreal3d : ARRAY[-5..-4,-1..0,0..1] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6, 560344.0005];
-    bLreal3d : ARRAY[1..2,4..5,6..7] OF LREAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5476.4002, -378.5003, 42.6001, 560344.0006];
-
+    
+    aLreal2d : ARRAY[-5..-3, -1..0] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5];
+    bLreal2d : ARRAY[1..3, 0..1] OF LREAL := [63.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003];
+    
+    aLreal3d : ARRAY[-5..-4, -1..0, 0..1] OF LREAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6, 560344.0005];
+    bLreal3d : ARRAY[1..2, 4..5, 6..7] OF LREAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5476.4002, -378.5003, 42.6001, 560344.0006];
+    
     aLword : ARRAY[1..2] OF LWORD := [16#01234567890ABCDE, 16#EDCBA09876543210];
     bLword : ARRAY[1..2] OF LWORD := [16#012345678A0ABCDE, 16#EDCBA09876543210];
-
+    
     aReal : ARRAY[-5..1] OF REAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6];
     bReal : ARRAY[1..7] OF REAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001];
-
-    aReal2d : ARRAY[-5..-3,-1..0] OF REAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5];
-    bReal2d : ARRAY[1..3,0..1] OF REAL := [64.0001, 98.0999, -32761.1995, 32767.3001, 5478.4002, -378.5003];
-
-    aReal3d : ARRAY[-5..-4,-1..0,0..1] OF REAL := [64.0, 93.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6, 560344.0005];
-    bReal3d : ARRAY[1..2,4..5,6..7] OF REAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001, 560344.0006];
-
+    
+    aReal2d : ARRAY[-5..-3, -1..0] OF REAL := [64.0, 98.1, -32768.2, 32767.3, 5478.4, -378.5];
+    bReal2d : ARRAY[1..3, 0..1] OF REAL := [64.0001, 98.0999, -32761.1995, 32767.3001, 5478.4002, -378.5003];
+    
+    aReal3d : ARRAY[-5..-4, -1..0, 0..1] OF REAL := [64.0, 93.1, -32768.2, 32767.3, 5478.4, -378.5, 42.6, 560344.0005];
+    bReal3d : ARRAY[1..2, 4..5, 6..7] OF REAL := [64.0001, 98.0999, -32768.1995, 32767.3001, 5478.4002, -378.5003, 42.6001, 560344.0006];
+    
     aSint : ARRAY[0..2] OF SINT := [-128, 127, -34];
     bSint : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
-
+    
     aUdint : ARRAY[1..3] OF UDINT := [0, 4294967295, 5000];
     bUdint : ARRAY[1..1] OF UDINT := [0];
-
+    
     aUint : ARRAY[0..4] OF UINT := [0, 65535, 2001, 34123, 59];
     bUint : ARRAY[0..4] OF UINT := [0, 65535, 2000, 34123, 59];
-
+    
     aUlint : ARRAY[0..3] OF ULINT := [0, 18_446_744_073_709_551_614, 9_400_000_000_000, 3_213_000_444_000];
     bUlint : ARRAY[0..3] OF ULINT := [0, 18_446_744_073_709_551_615, 9_400_000_000_000, 3_213_000_444_000];
-
+    
     aUsint : ARRAY[0..99] OF USINT := [42, 99(33)];
     bUsint : ARRAY[0..100] OF USINT := [42, 100(33)];
-
+    
     aWord : ARRAY[1..5] OF WORD := [16#AAAA, 16#BBBF, 16#CCCC, 16#DDDD, 16#EEEE];
     bWord : ARRAY[1..5] OF WORD := [16#AAAA, 16#BBBB, 16#CCCC, 16#DDDD, 16#EEEE];
     
-
     aSintDummy1 : ARRAY[0..3] OF SINT := [-128, 127, -34, 62];
     bSintDummy1 : ARRAY[0..3] OF SINT := [-128, 127, -34, 63];
-
+    
     aSintDummy2 : ARRAY[0..3] OF SINT := [-128, 127, -34, 64];
     bSintDummy2 : ARRAY[0..3] OF SINT := [-128, 127, -34, 65];
-
+    
     aSintDummy3 : ARRAY[0..3] OF SINT := [-128, 127, -34, 66];
     bSintDummy3 : ARRAY[0..3] OF SINT := [-128, 127, -34, 67];
-
+    
     aSintDummy4 : ARRAY[0..3] OF SINT := [-128, 127, -34, 68];
     bSintDummy4 : ARRAY[0..3] OF SINT := [-128, 127, -34, 69];
-
+    
     aSintDummy5 : ARRAY[0..3] OF SINT := [-128, 127, -34, 70];
     bSintDummy5 : ARRAY[0..3] OF SINT := [-128, 127, -34, 71];
-
+    
     aSintDummy6 : ARRAY[0..3] OF SINT := [-128, 127, -34, 72];
     bSintDummy6 : ARRAY[0..3] OF SINT := [-128, 127, -34, 73];
-
+    
     aSintDummy7 : ARRAY[0..3] OF SINT := [-128, 127, -34, 74];
     bSintDummy7 : ARRAY[0..3] OF SINT := [-128, 127, -34, 75];
-
+    
     aSintDummy8 : ARRAY[0..3] OF SINT := [-128, 127, -34, 76];
     bSintDummy8 : ARRAY[0..3] OF SINT := [-128, 127, -34, 77];
-
+    
     aSintDummy9 : ARRAY[0..3] OF SINT := [-128, 127, -34, 78];
     bSintDummy9 : ARRAY[0..3] OF SINT := [-128, 127, -34, 79];
-
+    
     aSintDummy10 : ARRAY[0..3] OF SINT := [-128, 127, -34, 80];
     bSintDummy10 : ARRAY[0..3] OF SINT := [-128, 127, -34, 81];
-
+    
     aSintDummy11 : ARRAY[0..3] OF SINT := [-128, 127, -34, 82];
     bSintDummy11 : ARRAY[0..3] OF SINT := [-128, 127, -34, 83];
-
+    
     aSintDummy12 : ARRAY[0..3] OF SINT := [-128, 127, -34, 84];
     bSintDummy12 : ARRAY[0..3] OF SINT := [-128, 127, -34, 85];
-
+    
     aSintDummy13 : ARRAY[0..3] OF SINT := [-128, 127, -34, 86];
     bSintDummy13 : ARRAY[0..3] OF SINT := [-128, 127, -34, 87];
-
+    
     aSintDummy14 : ARRAY[0..3] OF SINT := [-128, 127, -34, 88];
     bSintDummy14 : ARRAY[0..3] OF SINT := [-128, 127, -34, 89];
-
+    
     aSintDummy15 : ARRAY[0..3] OF SINT := [-128, 127, -34, 90];
     bSintDummy15 : ARRAY[0..3] OF SINT := [-128, 127, -34, 91];
-
+    
     aSintDummy16 : ARRAY[0..3] OF SINT := [-128, 127, -34, 92];
     bSintDummy16 : ARRAY[0..3] OF SINT := [-128, 127, -34, 93];
-
+    
     aSintDummy17 : ARRAY[0..3] OF SINT := [-128, 127, -34, 94];
     bSintDummy17 : ARRAY[0..3] OF SINT := [-128, 127, -34, 95];
-
+    
     aSintDummy18 : ARRAY[0..3] OF SINT := [-128, 127, -34, 96];
     bSintDummy18 : ARRAY[0..3] OF SINT := [-128, 127, -34, 97];
-
+    
     aSintDummy19 : ARRAY[0..3] OF SINT := [-128, 127, -34, 98];
     bSintDummy19 : ARRAY[0..3] OF SINT := [-128, 127, -34, 99];
-
+    
     aSintDummy20 : ARRAY[0..3] OF SINT := [-128, 127, -34, 100];
     bSintDummy20 : ARRAY[0..3] OF SINT := [-128, 127, -34, 101];
-
+    
     aSintDummy21 : ARRAY[0..3] OF SINT := [-128, 127, -34, 102];
     bSintDummy21 : ARRAY[0..3] OF SINT := [-128, 127, -34, 103];
-
+    
     aSintDummy22 : ARRAY[0..3] OF SINT := [-128, 127, -34, 104];
     bSintDummy22 : ARRAY[0..3] OF SINT := [-128, 127, -34, 105];
-
+    
     aSintDummy23 : ARRAY[0..3] OF SINT := [-128, 127, -34, 106];
     bSintDummy23 : ARRAY[0..3] OF SINT := [-128, 127, -34, 107];
-
+    
     aSintDummy24 : ARRAY[0..3] OF SINT := [-128, 127, -34, 108];
     bSintDummy24 : ARRAY[0..3] OF SINT := [-128, 127, -34, 109];
-
+    
     aSintDummy25 : ARRAY[0..3] OF SINT := [-128, 127, -34, 110];
     bSintDummy25 : ARRAY[0..3] OF SINT := [-128, 127, -34, 111];
-
+    
     aSintDummy26 : ARRAY[0..3] OF SINT := [-128, 127, -34, 112];
     bSintDummy26 : ARRAY[0..3] OF SINT := [-128, 127, -34, 113];
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('TestWith46FailedArrayAssertions');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestStreamBuffer.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestStreamBuffer.TcPOU
@@ -6,8 +6,9 @@
 *)
 FUNCTION_BLOCK FB_TestStreamBuffer EXTENDS TcUnit.FB_TestSuite
 VAR
-    Buffer: ARRAY [0..TcUnit.GVL_Param_TcUnit.XUnitBufferSize - 1] OF BYTE;
-END_VAR]]></Declaration>
+    Buffer : ARRAY [0..TcUnit.GVL_Param_TcUnit.XUnitBufferSize - 1] OF BYTE;
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Test_BufferSize();
 Test_Length();
@@ -19,7 +20,8 @@ Test_CutOff();
 Test_BufferOverflow();]]></ST>
     </Implementation>
     <Method Name="Setup" Id="{661742e7-8095-416e-ad24-7ce398db0b67}">
-      <Declaration><![CDATA[METHOD PRIVATE Setup]]></Declaration>
+      <Declaration><![CDATA[METHOD PRIVATE Setup
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Clear buffer
 Tc2_System.MEMSET(ADR(Buffer), 0, SIZEOF(Buffer));]]></ST>
@@ -33,7 +35,8 @@ VAR
     Str2 : STRING := 'Vincit qui se vincit.  ';
     Search : STRING := 'se';
     TestResult : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_Append');
 
@@ -60,11 +63,12 @@ VAR
     Str2 : STRING := 'uwxyz';
     Cpy : STRING;
     CopyLen : UDINT;
-    SmallBuffer : ARRAY [0..SMALL_BUFFER_SIZE-1] OF BYTE;
+    SmallBuffer : ARRAY [0..SMALL_BUFFER_SIZE - 1] OF BYTE;
 END_VAR
 VAR CONSTANT
     SMALL_BUFFER_SIZE : UDINT := 10;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BufferOverflow');
 
@@ -90,7 +94,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD PRIVATE Test_BufferSize
 VAR
     Stream : FB_StreamBuffer;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_BufferSize');
 
@@ -111,7 +116,8 @@ TEST_FINISHED();]]></ST>
 VAR
     Stream : FB_StreamBuffer;
     Str : STRING := 'vita est dolor sic ars';
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_Clear');
 
@@ -136,7 +142,8 @@ VAR
     Str2 : STRING := 'Vita est dolor sic ars.';
     Cpy : STRING;
     CopyLen : UDINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_Copy');
 
@@ -165,7 +172,8 @@ VAR
     Length : UDINT;
     CutOff : STRING;
     Expected : STRING;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_CutOff');
 
@@ -195,7 +203,8 @@ VAR
     Str : STRING := 'Vita est dolor sic ars.';
     Search : STRING := 'dolor';
     TestResult : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_Find');
 
@@ -219,7 +228,8 @@ VAR
     Stream : FB_StreamBuffer;
     Str : STRING := 'vita est dolor sic ars';
     Length : UDINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_Length');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestXmlControl.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestXmlControl.TcPOU
@@ -6,8 +6,9 @@
 *)
 FUNCTION_BLOCK FB_TestXmlControl EXTENDS TcUnit.FB_TestSuite
 VAR
-    Buffer: ARRAY[0..TcUnit.GVL_Param_TcUnit.xUnitBufferSize - 1] OF BYTE;
-END_VAR]]></Declaration>
+    Buffer : ARRAY[0..TcUnit.GVL_Param_TcUnit.xUnitBufferSize - 1] OF BYTE;
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Test_NewTag();
 Test_NewTagNested();
@@ -18,7 +19,8 @@ Test_CloseTag();
 Test_NewTagData();]]></ST>
     </Implementation>
     <Method Name="Setup" Id="{a523e726-082a-4e31-bdb5-31f9c8d19f4c}">
-      <Declaration><![CDATA[METHOD PRIVATE Setup]]></Declaration>
+      <Declaration><![CDATA[METHOD PRIVATE Setup
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Clear buffer
 Tc2_System.MEMSET(ADR(Buffer), 0, SIZEOF(Buffer));]]></ST>
@@ -33,7 +35,8 @@ VAR
     ActualBuffer : STRING;
     ExpectedResult : STRING;
     ActualResult : STRING;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_CloseOpenTag');
 
@@ -64,7 +67,8 @@ VAR
     ActualBuffer : STRING;
     ExpectedResult : STRING := '/MyTag';
     ActualResult : STRING;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_CloseTag');
 
@@ -94,7 +98,8 @@ VAR
     Comment : STRING := 'MyComment';
     ExpectedBuffer : STRING := '<!-- MyComment -->';
     ActualBuffer : STRING;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_NewComment');
 
@@ -119,7 +124,8 @@ VAR
     ParameterValue : STRING := 'Value';
     ExpectedBuffer : STRING := ' ParaName="Value"';
     ActualBuffer : STRING;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_NewParameter');
 
@@ -143,7 +149,8 @@ VAR
     TagName : STRING := 'MyTag';
     ExpectedBuffer : STRING := '<MyTag';
     ActualBuffer : STRING;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_NewTag');
 
@@ -167,7 +174,8 @@ VAR
     TagName : STRING := 'MyTag';
     ExpectedBuffer : STRING := '<MyTag>TagData';
     ActualBuffer : STRING;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_NewTagData');
 
@@ -195,7 +203,8 @@ VAR
     Tag4Name : STRING := 'MyTag4';
     ExpectedBuffer : STRING := '<MyTag1><MyTag2/><MyTag3/><MyTag4/></MyTag1>';
     ActualBuffer : STRING;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_NewTagNested');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_WriteProtectedFunctions.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_WriteProtectedFunctions.TcPOU
@@ -4,7 +4,8 @@
     <Declaration><![CDATA[(*
     This testsuite tests the WRITE_PROTECTED_* helper functions.
 *)
-FUNCTION_BLOCK FB_WriteProtectedFunctions EXTENDS TcUnit.FB_TestSuite]]></Declaration>
+FUNCTION_BLOCK FB_WriteProtectedFunctions EXTENDS TcUnit.FB_TestSuite
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Test_WRITE_PROTECTED_BOOL();
 Test_WRITE_PROTECTED_BYTE();
@@ -32,7 +33,8 @@ Test_WRITE_PROTECTED_WSTRING();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_BOOL
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_BOOL');
 
@@ -49,7 +51,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_BYTE
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_BYTE');
 
@@ -66,7 +69,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_DATE
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_DATE');
 
@@ -83,7 +87,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_DATE_AND_TIME
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_DATE_AND_TIME');
 
@@ -100,7 +105,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_DINT
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_DINT');
 
@@ -117,7 +123,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_DWORD
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_DWORD');
 
@@ -134,7 +141,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_INT
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_INT');
 
@@ -151,7 +159,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_LINT
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_LINT');
 
@@ -168,7 +177,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_LREAL
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_LREAL');
 
@@ -185,7 +195,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_LWORD
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_LWORD');
 
@@ -202,7 +213,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_REAL
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_REAL');
 
@@ -219,7 +231,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_SINT
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_SINT');
 
@@ -236,7 +249,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_STRING
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_STRING');
 
@@ -253,7 +267,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_TIME
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_TIME');
 
@@ -270,7 +285,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_TIME_OF_DAY
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_TIME_OF_DAY');
 
@@ -287,7 +303,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_UDINT
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_UDINT');
 
@@ -304,7 +321,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_UINT
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_UINT');
 
@@ -321,7 +339,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_ULINT
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_ULINT');
 
@@ -338,7 +357,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_USINT
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_USINT');
 
@@ -355,7 +375,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_WORD
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_WORD');
 
@@ -372,7 +393,8 @@ TEST_FINISHED();]]></ST>
       <Declaration><![CDATA[METHOD Test_WRITE_PROTECTED_WSTRING
 VAR
     ProtectedVariables : FB_ProtectedVariables;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Test_WRITE_PROTECTED_WSTRING');
 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/PRG_TEST.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/PRG_TEST.TcPOU
@@ -28,11 +28,12 @@ VAR
     TestXmlControl : FB_TestXmlControl;
     TestStreamBuffer : FB_TestStreamBuffer;
     TestFinishedNamed : FB_TestFinishedNamed;
-
+    
     (* The testsuite below is not active, as it will make TcUnit to abort. Uncomment if you want
        to test the function of where a test with a name that doesn't exist is set to finished *)
     //TestFinishedNamedDoesNotExist : FB_TestFinishedNamedDoesNotExist;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[TcUnit.RUN();]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/ITFs/I_AssertMessageFormatter.TcIO
+++ b/TcUnit/TcUnit/ITFs/I_AssertMessageFormatter.TcIO
@@ -10,7 +10,8 @@ VAR_INPUT
     Actual : Tc2_System.T_MaxString;
     Message : Tc2_System.T_MaxString;
     TestInstancePath : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     </Method>
   </Itf>
 </TcPlcObject>

--- a/TcUnit/TcUnit/ITFs/I_TestResultLogger.TcIO
+++ b/TcUnit/TcUnit/ITFs/I_TestResultLogger.TcIO
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <Itf Name="I_TestResultLogger" Id="{fa75ee61-43fb-4767-8061-125a3a9e3424}">
-    <Declaration><![CDATA[INTERFACE I_TestResultLogger]]></Declaration>
+    <Declaration><![CDATA[INTERFACE I_TestResultLogger
+]]></Declaration>
     <Method Name="LogTestSuiteResults" Id="{033e8873-ad7a-489b-8ba9-f0de8a344939}">
-      <Declaration><![CDATA[METHOD PUBLIC LogTestSuiteResults]]></Declaration>
+      <Declaration><![CDATA[METHOD PUBLIC LogTestSuiteResults
+]]></Declaration>
     </Method>
   </Itf>
 </TcPlcObject>

--- a/TcUnit/TcUnit/ITFs/I_TestResults.TcIO
+++ b/TcUnit/TcUnit/ITFs/I_TestResults.TcIO
@@ -8,7 +8,7 @@
 ]]></Declaration>
     </Method>
     <Method Name="GetTestSuiteResults" Id="{f78f0f3e-a842-41e1-b891-bfd5e3fc0531}">
-      <Declaration><![CDATA[METHOD GetTestSuiteResults : REFERENCE TO ST_TestSuiteResults;
+      <Declaration><![CDATA[METHOD GetTestSuiteResults : REFERENCE TO ST_TestSuiteResults
 ]]></Declaration>
     </Method>
   </Itf>

--- a/TcUnit/TcUnit/POUs/FB_AdjustAssertFailureMessageToMax253CharLength.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_AdjustAssertFailureMessageToMax253CharLength.TcPOU
@@ -21,7 +21,8 @@ VAR
 END_VAR
 VAR CONSTANT
     MSG_FMT_STRING_MAX_NUMBER_OF_CHARACTERS : INT := 253; // This is actually 254, but if StrArg-argument is used (which it is in TcUnit) it is 253.
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[// Check if any of the two strings are too long (or the combination of them)
 

--- a/TcUnit/TcUnit/POUs/FB_AdsAssertMessageFormatter.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_AdsAssertMessageFormatter.TcPOU
@@ -6,7 +6,8 @@
     ADSLOGSTR functionality provided by the Tc2_System library. This sends the result using ADS, which
     is consumed by the error list of Visual Studio.
 *)
-FUNCTION_BLOCK FB_AdsAssertMessageFormatter IMPLEMENTS I_AssertMessageFormatter]]></Declaration>
+FUNCTION_BLOCK FB_AdsAssertMessageFormatter IMPLEMENTS I_AssertMessageFormatter
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>
@@ -25,7 +26,8 @@ VAR
     ReturnValue : DINT;
     TestInstancePathProcessed : Tc2_System.T_MaxString;
     MessageProcessed : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TestInstancePathCleaned := F_RemoveInstancePathAndProjectNameFromTestInstancePath(TestInstancePath);
 TestInstancePathFinal := Tc2_Standard.CONCAT(STR1 := 'FAILED TEST $'', STR2 := TestInstancePathCleaned);

--- a/TcUnit/TcUnit/POUs/FB_AdsLogStringMessageFifoQueue.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_AdsLogStringMessageFifoQueue.TcPOU
@@ -9,7 +9,7 @@ FUNCTION_BLOCK FB_AdsLogStringMessageFifoQueue
 VAR
     ArrayBuffer : ARRAY[0..((GVL_Param_TcUnit.AdsLogMessageFifoRingBufferSize * (SIZEOF(ST_ADSLogStringMessage) + MEM_RING_BUFFER_INTERNAL_USE_PER_DATA_RECORD)) - 1)] OF BYTE;
     MemRingBuffer : Tc2_Utilities.FB_MemRingBuffer;
-    TimerBetweenMessages : Tc2_Standard.TON := (IN := TRUE, PT := TIME_BETWEEN_MESSAGES);
+    TimerBetweenMessages : Tc2_Standard.TON := (IN:=TRUE, PT:=TIME_BETWEEN_MESSAGES);
 END_VAR
 VAR CONSTANT
     MEM_RING_BUFFER_INTERNAL_USE_PER_DATA_RECORD : USINT := 4;
@@ -19,7 +19,8 @@ VAR_TEMP
     MessageToBeSent : ST_ADSLogStringMessage;
     ErrorGet : BOOL;
     ReturnValue : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[TimerBetweenMessages();
 IF GetLogCount() > 0 THEN
@@ -43,7 +44,8 @@ METHOD PRIVATE GetAndRemoveLogFromQueue
 VAR_OUTPUT
     AdsLogStringMessage : ST_ADSLogStringMessage;
     Error : BOOL; // Buffer empty
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[MemRingBuffer.A_RemoveHead(pRead := ADR(AdsLogStringMessage),
                            cbRead := SIZEOF(ST_ADSLogStringMessage),
@@ -53,7 +55,8 @@ Error := NOT MemRingBuffer.bOk;]]></ST>
       </Implementation>
     </Method>
     <Method Name="GetLogCount" Id="{b92b4756-7e23-4fd6-b9d4-ba80d89e5be5}">
-      <Declaration><![CDATA[METHOD PRIVATE GetLogCount : UDINT]]></Declaration>
+      <Declaration><![CDATA[METHOD PRIVATE GetLogCount : UDINT
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[GetLogCount := MemRingBuffer.nCount;]]></ST>
       </Implementation>
@@ -71,7 +74,8 @@ VAR_OUTPUT
 END_VAR
 VAR
     AdsLogStringMessage : ST_AdsLogStringMessage;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[(* Only log message types of ERROR if log extended results is not enabled *)
 IF MsgCtrlMask = Tc2_System.ADSLOG_MSGTYPE_ERROR OR GVL_Param_TcUnit.LogExtendedResults THEN

--- a/TcUnit/TcUnit/POUs/FB_AdsTestResultLogger.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_AdsTestResultLogger.TcPOU
@@ -9,24 +9,25 @@
 FUNCTION_BLOCK FB_AdsTestResultLogger IMPLEMENTS I_TestResultLogger
 VAR
     TestResults : I_TestResults;
-
+    
     PrintingTestSuiteResultNumber : UINT(1..GVL_Param_TcUnit.MaxNumberOfTestSuites);
     PrintingTestSuiteTrigger : Tc2_Standard.R_TRIG;
-
+    
     (* This flag is set once the final end result has printed *)
     PrintedFinalTestResults : BOOL;
-
+    
     (* This flag is set once the test suites result have been printed *)
     PrintedTestSuitesResults : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>
     <Method Name="FB_init" Id="{351baac4-80f0-4844-87bd-6da6e16d230c}">
       <Declaration><![CDATA[METHOD FB_init : BOOL
 VAR_INPUT
-	bInitRetains : BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
-	bInCopyCode : BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
+    bInitRetains : BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
+    bInCopyCode : BOOL; // if TRUE, the instance afterwards gets moved into the copy code (online change)
     iTestResults : I_TestResults;
 END_VAR
 ]]></Declaration>
@@ -38,14 +39,15 @@ END_VAR
       <Declaration><![CDATA[METHOD PUBLIC LogTestSuiteResults
 VAR
     TcUnitTestResults : REFERENCE TO ST_TestSuiteResults;
-    StringToPrint : Tc2_System.T_MaxString; 
+    StringToPrint : Tc2_System.T_MaxString;
     TestsInTestSuiteCounter : UINT(1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite);
 END_VAR
 VAR CONSTANT
     TEST_STATUS_SKIP : STRING := 'SKIP';
     TEST_STATUS_PASS : STRING := 'PASS';
     TEST_STATUS_FAIL : STRING := 'FAIL';
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TcUnitTestResults REF= TestResults.GetTestSuiteResults();
 

--- a/TcUnit/TcUnit/POUs/FB_AssertArrayResultStatic.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_AssertArrayResultStatic.TcPOU
@@ -17,22 +17,23 @@ FUNCTION_BLOCK FB_AssertArrayResultStatic
 VAR
     (* The total number of instances of each of the "AssertArrayResults" *)
     AssertArrayResults : ARRAY[1..GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite] OF ST_AssertArrayResult;
-
+    
     (* The total number of unique asserts *)
     TotalArrayAsserts : UINT := 0;
-
+    
     (* Function block to get the current task cycle *)
     GetCurrentTaskIndex : Tc2_System.GETCURTASKINDEX;
-
+    
     (* The total number of instances of each of the "AssertArrayResults" *)
     AssertArrayResultInstances : ARRAY[1..GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite] OF ST_AssertArrayResultInstances;
-
+    
     (* The last PLC cycle count *)
     CycleCount : UDINT;
-
+    
     (* Only run first cycle *)
     FirstCycleExecuted : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>
@@ -45,7 +46,8 @@ VAR_INPUT
     ActualsTypeClass : IBaseLibrary.TypeClass;
     Message : Tc2_System.T_MaxString;
     TestInstancePath : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TotalArrayAsserts := TotalArrayAsserts + 1;
 AssertArrayResults[TotalArrayAsserts].ExpectedsSize := ExpectedsSize;
@@ -60,7 +62,8 @@ AssertArrayResults[TotalArrayAsserts].TestInstancePath := TestInstancePath;]]></
       <Declaration><![CDATA[METHOD PRIVATE CopyDetectionCountAndResetDetectionCountInThisCycle
 VAR
     IteratorCounter : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[FOR IteratorCounter := 1 TO GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite BY 1 DO
     AssertArrayResultInstances[IteratorCounter].DetectionCount := AssertArrayResultInstances[IteratorCounter].DetectionCountThisCycle;
@@ -80,7 +83,8 @@ VAR_INPUT
 END_VAR
 VAR
     IteratorCounter : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[FOR IteratorCounter := 1 TO GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite BY 1 DO
     IF AssertArrayResultInstances[IteratorCounter].DetectionCount = 0 AND
@@ -109,7 +113,8 @@ VAR_INPUT
 END_VAR
 VAR
     IteratorCounter : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[FOR IteratorCounter := 1 TO GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite BY 1 DO
     IF AssertArrayResultInstances[IteratorCounter].AssertArrayResult.ExpectedsSize = ExpectedsSize AND
@@ -135,7 +140,8 @@ VAR_INPUT
 END_VAR
 VAR
     IteratorCounter : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[FOR IteratorCounter := 1 TO GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite BY 1 DO
     IF AssertArrayResultInstances[IteratorCounter].AssertArrayResult.ExpectedsSize = ExpectedsSize AND
@@ -158,7 +164,8 @@ END_VAR
 VAR
     Counter : UINT;
     NumberOfArrayAsserts : UINT := 0;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF TotalArrayAsserts > 0 THEN
     FOR Counter := 1 TO TotalArrayAsserts BY 1 DO
@@ -224,7 +231,8 @@ VAR
     DetectionCountTemp : UINT := 0;
     FoundOne : BOOL;
     AdditionalIdenticalAssert : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF NOT FirstCycleExecuted THEN
     GetCurrentTaskIndex();

--- a/TcUnit/TcUnit/POUs/FB_AssertResultStatic.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_AssertResultStatic.TcPOU
@@ -15,22 +15,23 @@ FUNCTION_BLOCK FB_AssertResultStatic
 VAR
     (* The total number of instances of each of the "AssertResults" *)
     AssertResults : ARRAY[1..GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite] OF ST_AssertResult;
-
+    
     (* The total number of unique asserts *)
     TotalAsserts : UINT := 0;
-
+    
     (* Function block to get the current task cycle *)
     GetCurrentTaskIndex : Tc2_System.GETCURTASKINDEX;
-
+    
     (* The total number of instances of each of the "AssertResults" *)
     AssertResultInstances : ARRAY[1..GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite] OF ST_AssertResultInstances;
-
+    
     (* The last PLC cycle count *)
     CycleCount : UDINT;
-
+    
     (* Only run first cycle *)
     FirstCycleExecuted : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>
@@ -59,7 +60,8 @@ AssertResults[TotalAsserts].TestInstancePath := TestInstancePath;]]></ST>
       <Declaration><![CDATA[METHOD PRIVATE CopyDetectionCountAndResetDetectionCountInThisCycle
 VAR
     IteratorCounter : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[FOR IteratorCounter := 1 TO GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite BY 1 DO
     AssertResultInstances[IteratorCounter].DetectionCount := AssertResultInstances[IteratorCounter].DetectionCountThisCycle;
@@ -81,7 +83,8 @@ VAR_INPUT
 END_VAR
 VAR
     IteratorCounter : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[FOR IteratorCounter := 1 TO GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite BY 1 DO
     IF AssertResultInstances[IteratorCounter].DetectionCount = 0 AND
@@ -110,7 +113,8 @@ VAR_INPUT
 END_VAR
 VAR
     IteratorCounter : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[FOR IteratorCounter := 1 TO GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite BY 1 DO
     IF F_IsAnyEqualToUnionValue(uExpectedOrActual := AssertResultInstances[IteratorCounter].AssertResult.Expected,
@@ -142,7 +146,8 @@ VAR_INPUT
 END_VAR
 VAR
     IteratorCounter : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[FOR IteratorCounter := 1 TO GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite BY 1 DO
     IF F_IsAnyEqualToUnionValue(uExpectedOrActual := AssertResultInstances[IteratorCounter].AssertResult.Expected,
@@ -168,7 +173,8 @@ END_VAR
 VAR
     Counter : UINT;
     NumberOfAsserts : UINT := 0;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF TotalAsserts > 0 THEN
     FOR Counter := 1 TO TotalAsserts BY 1 DO
@@ -233,7 +239,8 @@ VAR
     DetectionCountTemp : UINT := 0;
     FoundOne : BOOL;
     AdditionalIdenticalAssert : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF NOT FirstCycleExecuted THEN
     GetCurrentTaskIndex();

--- a/TcUnit/TcUnit/POUs/FB_FileControl.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_FileControl.TcPOU
@@ -6,9 +6,10 @@
 *)
 FUNCTION_BLOCK FB_FileControl
 VAR
-    FileAccessMode : SysFile.ACCESS_MODE := SysFile.AM_APPEND_PLUS; // Append_Plus creates the file if it doesn't exist yet. 
+    FileAccessMode : SysFile.ACCESS_MODE := SysFile.AM_APPEND_PLUS; // Append_Plus creates the file if it doesn't exist yet.
     FileHandle : SysFile.SysTypes.RTS_IEC_HANDLE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>
@@ -16,7 +17,8 @@ END_VAR]]></Declaration>
       <Declaration><![CDATA[(*
     Closes the current opened file.
 *)
-METHOD PUBLIC Close : SysFile.SysTypes.RTS_IEC_RESULT;]]></Declaration>
+METHOD PUBLIC Close : SysFile.SysTypes.RTS_IEC_RESULT
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF FileHandle <> SysFile.SysTypes.RTS_INVALID_HANDLE THEN
     Close := SysFile.SysFileClose(hFile := FileHandle);
@@ -29,11 +31,12 @@ END_IF]]></ST>
       <Declaration><![CDATA[(*
     Deletes a file specified by name, if it exists.
 *)
-METHOD PUBLIC Delete : SysFile.SysTypes.RTS_IEC_RESULT;
+METHOD PUBLIC Delete : SysFile.SysTypes.RTS_IEC_RESULT
 VAR_INPUT
     (* File name can contain an absolute or relative path to the file. Path entries must be separated with a forward slash (/) *)
     FileName : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[Delete := SysFile.SysFileDelete(szFileName := FileName);]]></ST>
       </Implementation>
@@ -42,11 +45,12 @@ END_VAR]]></Declaration>
       <Declaration><![CDATA[(*
     Opens a file
 *)
-METHOD PUBLIC Open : SysFile.SysTypes.RTS_IEC_RESULT;
+METHOD PUBLIC Open : SysFile.SysTypes.RTS_IEC_RESULT
 VAR_INPUT
-    FileName : Tc2_System.T_MaxString := 'filepath/output.xml';  // File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)
+    FileName : Tc2_System.T_MaxString := 'filepath/output.xml'; // File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)
     FileAccessMode : SysFile.ACCESS_MODE := SysFile.ACCESS_MODE.AM_APPEND_PLUS;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[FileHandle := SysFile.SysFileOpen(szFile := Filename,
                                   am := FileAccessMode,
@@ -57,14 +61,15 @@ END_VAR]]></Declaration>
       <Declaration><![CDATA[(*
     Reads a file from disk into the buffer
 *)
-METHOD Read : SysFile.SysTypes.RTS_IEC_RESULT;
+METHOD Read : SysFile.SysTypes.RTS_IEC_RESULT
 VAR_INPUT
     BufferPointer : POINTER TO BYTE; // Call with ADR();
-    Size : UDINT; // Call with SIZEOF(); 
+    Size : UDINT; // Call with SIZEOF();
 END_VAR
 VAR_OUTPUT
     FileSize : SysFile.SysTypes.RTS_IEC_SIZE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF FileHandle <> SysFile.SysTypes.RTS_INVALID_HANDLE THEN
     FileSize := SysFile.SysFileRead(hFile := FileHandle, 
@@ -80,11 +85,12 @@ END_IF]]></ST>
       <Declaration><![CDATA[(* 
     Writes the contents of the buffer into a file.
 *)
-METHOD Write : SysFile.SysTypes.RTS_IEC_RESULT;
+METHOD Write : SysFile.SysTypes.RTS_IEC_RESULT
 VAR_INPUT
     BufferPointer : POINTER TO BYTE; // Call with ADR();
     Size : UDINT; // Call with SIZEOF();
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF FileHandle <> SysFile.SysTypes.RTS_INVALID_HANDLE THEN
     SysFile.SysFileWrite(hFile := FileHandle,

--- a/TcUnit/TcUnit/POUs/FB_StreamBuffer.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_StreamBuffer.TcPOU
@@ -4,12 +4,13 @@
     <Declaration><![CDATA[(*
     This functionblock acts as a stream buffer for use with FB_XmlControl
 *)
-FUNCTION_BLOCK FB_StreamBuffer 
+FUNCTION_BLOCK FB_StreamBuffer
 VAR
     _PointerToStringBuffer : POINTER TO BYTE;
     _BufferSize : UDINT;
     _Length : UDINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>
@@ -17,12 +18,14 @@ END_VAR]]></Declaration>
       <Declaration><![CDATA[(*
     Appends a string to the buffer
 *)
-PROPERTY Append : Tc2_System.T_MaxString]]></Declaration>
+PROPERTY Append : Tc2_System.T_MaxString
+]]></Declaration>
       <Set Name="Set" Id="{773bf1db-6b9a-4581-be33-e4745bbc41df}">
         <Declaration><![CDATA[VAR
     ByteIn : POINTER TO BYTE;
     ByteBuffer : POINTER TO BYTE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
         <Implementation>
           <ST><![CDATA[ByteIn := ADR(Append); 
 ByteBuffer := _PointerToStringBuffer + _Length; // set start address
@@ -43,7 +46,8 @@ ByteBuffer^ := 0; // null terminated string]]></ST>
       <Declaration><![CDATA[(*
     Read current Buffersize
 *)
-PROPERTY BufferSize : UDINT]]></Declaration>
+PROPERTY BufferSize : UDINT
+]]></Declaration>
       <Get Name="Get" Id="{41dc436d-8e79-4934-92fd-8311aee18e1d}">
         <Declaration><![CDATA[]]></Declaration>
         <Implementation>
@@ -57,8 +61,9 @@ PROPERTY BufferSize : UDINT]]></Declaration>
 *)
 METHOD PUBLIC Clear
 VAR
-	Count : UDINT;
-END_VAR]]></Declaration>
+    Count : UDINT;
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF (_PointerToStringBuffer = 0) OR (_BufferSize = 0) THEN
     RETURN;
@@ -89,7 +94,8 @@ VAR
     PointerToByteToCopy : POINTER TO BYTE;
     PointerToBuffer : POINTER TO BYTE;
     CurPos : UDINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[Loop := 0;
 PointerToByteToCopy := ADR(Copy);
@@ -120,14 +126,15 @@ VAR_INPUT
     StartPos : UDINT;
 END_VAR
 VAR_OUTPUT
-    CutLen : UDINT; 
+    CutLen : UDINT;
     XmlError : E_XmlError;
 END_VAR
 VAR
     Loop : UDINT;
     PointerToByteToCut : POINTER TO BYTE;
     PointerToByteBuffer : POINTER TO BYTE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[Loop := 0;
 PointerToByteToCut := ADR(CutOff);
@@ -172,7 +179,8 @@ VAR
     Search : UDINT;
     PointerToBuffer : POINTER TO BYTE;
     PointerToSearch : POINTER TO BYTE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[Loop := 0;
 Search := 0;
@@ -205,7 +213,8 @@ VAR
     Search : UDINT;
     PointerToBuffer : POINTER TO BYTE;
     PointerToSearch : POINTER TO BYTE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[Loop := 0;
 Search := 0;
@@ -232,7 +241,8 @@ FindBack := _Length - Loop + 1;]]></ST>
       <Declaration><![CDATA[(*
     Gets/Sets the current length (in bytes) of the streambuffer
 *)
-PROPERTY Length : UDINT]]></Declaration>
+PROPERTY Length : UDINT
+]]></Declaration>
       <Get Name="Get" Id="{d9ee832e-be82-4ebc-bf0b-bb382927ac05}">
         <Declaration><![CDATA[]]></Declaration>
         <Implementation>
@@ -247,11 +257,12 @@ PROPERTY Length : UDINT]]></Declaration>
       </Set>
     </Property>
     <Method Name="SetBuffer" Id="{bbd47c2a-5140-429c-a3f1-6edaac587279}">
-      <Declaration><![CDATA[METHOD PUBLIC SetBuffer : BOOL;
+      <Declaration><![CDATA[METHOD PUBLIC SetBuffer : BOOL
 VAR_INPUT
     PointerToBufferAddress : POINTER TO BYTE; // Set buffer address (ADR ...)
     SizeOfBuffer : UDINT; // Set buffer size (SIZEOF ...)
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF (PointerToBufferAddress = 0) OR (SizeOfBuffer = 0) THEN
     SetBuffer := FALSE;

--- a/TcUnit/TcUnit/POUs/FB_TcUnitRunner.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_TcUnitRunner.TcPOU
@@ -8,30 +8,32 @@ FUNCTION_BLOCK FB_TcUnitRunner
 VAR
     (* Indication of whether all test suites have reported that they are finished *)
     AllTestSuitesFinished : BOOL := FALSE;
-
+    
     (* Test result information *)
     TestResults : FB_TestResults;
-
+    
     (* Prints the results to ADS so that Visual Studio can display the results.
        This test result formatter can be replaced with something else than ADS *)
     AdsTestResultLogger : FB_AdsTestResultLogger(TestResults);
     TestResultLogger : I_TestResultLogger := AdsTestResultLogger;
-
+    
     (* If this flag is set, it means that some external event triggered the
        request to abort running the test suites *)
     AbortRunningTestSuites : BOOL;
-
+    
     (* Publishes a xUnit compatible XML file *)
     xUnitXmlPublisher : FB_xUnitXmlPublisher(TestResults);
     XmlTestResultPublisher : I_TestResultLogger := xUnitXmlPublisher;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>
     <Method Name="AbortRunningTestSuiteTests" Id="{3fcbd569-749a-493c-a697-2c976fa6e96a}">
       <Declaration><![CDATA[(* This function sets a flag which makes the runner stop running the tests
    in the test suites *)
-METHOD PUBLIC AbortRunningTestSuiteTests]]></Declaration>
+METHOD PUBLIC AbortRunningTestSuiteTests
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[AbortRunningTestSuites := TRUE;]]></ST>
       </Implementation>
@@ -46,7 +48,8 @@ VAR
        The reason we want to do it this way is because a test suite can run over several cycles. Only once all tests
        are finished (which might take many cycles), do we gather correct statistics *)
     NumberOfTestSuitesFinished : UINT := 0;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[(* Run TcUnit test suites *)
 IF NOT AllTestSuitesFinished THEN

--- a/TcUnit/TcUnit/POUs/FB_Test.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_Test.TcPOU
@@ -6,57 +6,65 @@
 *)
 FUNCTION_BLOCK FB_Test
 VAR
-    TestName : Tc2_System.T_MaxString; 
+    TestName : Tc2_System.T_MaxString;
     TestIsFinished : BOOL;
     TestIsSkipped : BOOL; // This is set to true, if test is disabled (by putting the string "disabled_" in front of the test name
     NumberOfAssertions : UINT;
-
+    
     (* Failure parameters. If TestIsFailed is TRUE, the other parameters will hold values as well *)
     TestIsFailed : BOOL; // Indication of whether this test has at least one failed assert
     AssertionMessage : Tc2_System.T_MaxString; // Assertion message for the first assertion in this test
     AssertionType : E_AssertionType; // Assertion type for the first assertion in this test
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>
     <Method Name="GetAssertionMessage" Id="{273c4e89-faee-43b5-803d-428cdf75ac48}">
-      <Declaration><![CDATA[METHOD PUBLIC GetAssertionMessage : Tc2_System.T_MaxString]]></Declaration>
+      <Declaration><![CDATA[METHOD PUBLIC GetAssertionMessage : Tc2_System.T_MaxString
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[GetAssertionMessage := AssertionMessage;]]></ST>
       </Implementation>
     </Method>
     <Method Name="GetAssertionType" Id="{cd1419c3-7b07-4183-b487-40bdbb0bbce3}">
-      <Declaration><![CDATA[METHOD PUBLIC GetAssertionType : E_AssertionType]]></Declaration>
+      <Declaration><![CDATA[METHOD PUBLIC GetAssertionType : E_AssertionType
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[GetAssertionType := AssertionType;]]></ST>
       </Implementation>
     </Method>
     <Method Name="GetName" Id="{94757f0e-9979-49d0-ad9f-e35c823175d4}">
-      <Declaration><![CDATA[METHOD PUBLIC GetName : Tc2_System.T_MaxString;]]></Declaration>
+      <Declaration><![CDATA[METHOD PUBLIC GetName : Tc2_System.T_MaxString
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[GetName := TestName;]]></ST>
       </Implementation>
     </Method>
     <Method Name="GetNumberOfAssertions" Id="{0cfa1f03-0295-4f8f-bfd9-24d7b7f17e37}">
-      <Declaration><![CDATA[METHOD PUBLIC GetNumberOfAssertions : UINT]]></Declaration>
+      <Declaration><![CDATA[METHOD PUBLIC GetNumberOfAssertions : UINT
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[GetNumberOfAssertions := NumberOfAssertions;]]></ST>
       </Implementation>
     </Method>
     <Method Name="IsFailed" Id="{e42409e3-251f-4133-8b14-3630785983d6}">
-      <Declaration><![CDATA[METHOD PUBLIC IsFailed : BOOL]]></Declaration>
+      <Declaration><![CDATA[METHOD PUBLIC IsFailed : BOOL
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IsFailed := TestIsFailed;]]></ST>
       </Implementation>
     </Method>
     <Method Name="IsFinished" Id="{813a9067-b864-4739-9c14-830160e0eabc}">
-      <Declaration><![CDATA[METHOD PUBLIC IsFinished : BOOL]]></Declaration>
+      <Declaration><![CDATA[METHOD PUBLIC IsFinished : BOOL
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IsFinished := TestIsFinished;]]></ST>
       </Implementation>
     </Method>
     <Method Name="IsSkipped" Id="{ff97feb1-1a4a-4f36-ba1d-f8483e588d4f}">
-      <Declaration><![CDATA[METHOD PUBLIC IsSkipped : BOOL]]></Declaration>
+      <Declaration><![CDATA[METHOD PUBLIC IsSkipped : BOOL
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IsSkipped := TestIsSkipped;]]></ST>
       </Implementation>
@@ -66,7 +74,8 @@ END_VAR]]></Declaration>
 METHOD PUBLIC SetAssertionMessage
 VAR_INPUT
     AssertMessage : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF Tc2_Standard.LEN(STR := AssertionMessage) = 0 THEN
     AssertionMessage := AssertMessage;
@@ -78,7 +87,8 @@ END_IF]]></ST>
 METHOD PUBLIC SetAssertionType
 VAR_INPUT
     AssertType : E_AssertionType;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF AssertionType = E_AssertionType.Type_UNDEFINED THEN
     AssertionType := AssertType;
@@ -86,13 +96,15 @@ END_IF]]></ST>
       </Implementation>
     </Method>
     <Method Name="SetFailed" Id="{b840b41b-4045-4fd9-b97d-0bf226c46fb3}">
-      <Declaration><![CDATA[METHOD PUBLIC SetFailed]]></Declaration>
+      <Declaration><![CDATA[METHOD PUBLIC SetFailed
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TestIsFailed := TRUE;]]></ST>
       </Implementation>
     </Method>
     <Method Name="SetFinished" Id="{e1245d1c-be22-4d60-bc91-fe0262827234}">
-      <Declaration><![CDATA[METHOD SetFinished : BOOL]]></Declaration>
+      <Declaration><![CDATA[METHOD SetFinished : BOOL
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TestIsFinished := TRUE;]]></ST>
       </Implementation>
@@ -101,7 +113,8 @@ END_IF]]></ST>
       <Declaration><![CDATA[METHOD PUBLIC SetName
 VAR_INPUT
     Name : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TestName := Name;]]></ST>
       </Implementation>
@@ -110,14 +123,16 @@ END_VAR]]></Declaration>
       <Declaration><![CDATA[METHOD PUBLIC SetNumberOfAssertions
 VAR_INPUT
     NoOfAssertions : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[NumberOfAssertions := NoOfAssertions;]]></ST>
       </Implementation>
     </Method>
     <Method Name="SetSkipped" Id="{e9a94cad-c60d-4460-92bf-2b70cf2f46b2}">
       <Declaration><![CDATA[(* Sets the test case to skipped *)
-METHOD PUBLIC SetSkipped]]></Declaration>
+METHOD PUBLIC SetSkipped
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TestIsSkipped := TRUE;]]></ST>
       </Implementation>

--- a/TcUnit/TcUnit/POUs/FB_TestResults.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_TestResults.TcPOU
@@ -6,7 +6,7 @@ FUNCTION_BLOCK FB_TestResults IMPLEMENTS I_TestResults
 VAR
     (* Test results *)
     TestSuiteResults : ST_TestSuiteResults;
-
+    
     (* Misc variables *)
     StoringTestSuiteResultNumber : UINT(1..GVL_Param_TcUnit.MaxNumberOfTestSuites);
     StoringTestSuiteTrigger : Tc2_Standard.R_TRIG;
@@ -16,12 +16,13 @@ END_VAR
 VAR_TEMP
     TestSuiteName : Tc2_System.T_MaxString;
     TestName : Tc2_System.T_MaxString;
-
+    
     TestsInTestSuiteCounter : UINT(1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite);
-
+    
     TestToBeStored : FB_Test;
     GeneralTestResultsTestSuitesCounter : UINT(1..GVL_Param_TcUnit.MaxNumberOfTestSuites);
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[(* The body of the function block stores the test results *)
 IF StoringTestSuiteResultNumber <= GVL_TcUnit.NumberOfInitializedTestSuites AND NOT StoredTestSuiteResults THEN
@@ -98,13 +99,15 @@ END_IF]]></ST>
     </Implementation>
     <Method Name="GetAreTestResultsAvailable" Id="{1405a17f-835e-481b-8bc4-6f447bc860a2}">
       <Declaration><![CDATA[(* Returns whether the storing of the test results is finished *)
-METHOD PUBLIC GetAreTestResultsAvailable : BOOL]]></Declaration>
+METHOD PUBLIC GetAreTestResultsAvailable : BOOL
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[GetAreTestResultsAvailable := (StoredTestSuiteResults AND StoredGeneralTestResults);]]></ST>
       </Implementation>
     </Method>
     <Method Name="GetTestSuiteResults" Id="{3d7cfdb1-16a3-456d-be0a-82cecf4820a8}">
-      <Declaration><![CDATA[METHOD PUBLIC GetTestSuiteResults : REFERENCE TO ST_TestSuiteResults;]]></Declaration>
+      <Declaration><![CDATA[METHOD PUBLIC GetTestSuiteResults : REFERENCE TO ST_TestSuiteResults
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[GetTestSuiteResults REF=TestSuiteResults;]]></ST>
       </Implementation>

--- a/TcUnit/TcUnit/POUs/FB_TestSuite.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_TestSuite.TcPOU
@@ -13,13 +13,13 @@ VAR
     {attribute 'instance-path'}
     {attribute 'noinit'}
     InstancePath : Tc2_System.T_MaxString;
-
+    
     (* We need to have access to specific information of the current task that this test suite
        is executed in. This is for instance necessary when we need to know whether a test is
        defined already. The definition of a test that is defined already is that we call on it
        with the same name twice in the same cycle *)
     GetCurrentTaskIndex : Tc2_System.GETCURTASKINDEX;
-
+    
     NumberOfTests : UINT(0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite) := 0;
     Tests : ARRAY[1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite] OF FB_Test;
     (* Rising trigger of whether we have already notified the user of that the test name pointed to by the current
@@ -28,15 +28,16 @@ VAR
     (* Last cycle count index for a specific test. Used to detect whether this test has already been defined in the
        current test suite *)
     TestCycleCountIndex : ARRAY[1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite] OF UDINT;
-
+    
     AssertResults : FB_AssertResultStatic;
     AssertArrayResults : FB_AssertArrayResultStatic;
-
+    
     (* Prints the failed asserts to ADS so that Visual Studio can display the assert message.
        This assert formatter can be replaced with something else than ADS *)
     AdsAssertMessageFormatter : FB_AdsAssertMessageFormatter;
     AssertMessageFormatter : I_AssertMessageFormatter := AdsAssertMessageFormatter;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>
@@ -55,7 +56,8 @@ VAR
     LowerCasedTestName : Tc2_System.T_MaxString;
     TrimmedTestName : Tc2_System.T_MaxString;
     IgnoreCurrentTestCase : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[GVL_TcUnit.IgnoreCurrentTest := FALSE; // Reset the ignore current test flag
 
@@ -125,7 +127,8 @@ VAR_INPUT
 END_VAR
 VAR
     CompleteTestInstancePath : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[CompleteTestInstancePath := Tc2_Utilities.CONCAT(STR1 := TestInstancePath, STR2 := '@');
 AddTestNameToInstancePath := Tc2_Utilities.CONCAT(STR1 := CompleteTestInstancePath, STR2 := GVL_TcUnit.CurrentTestNameBeingCalled);]]></ST>
@@ -135,9 +138,10 @@ AddTestNameToInstancePath := Tc2_Utilities.CONCAT(STR1 := CompleteTestInstancePa
       <Declaration><![CDATA[METHOD PUBLIC AreAllTestsFinished : BOOL
 VAR
     Counter : UINT;
-
+    
     GetCurTaskIndex : Tc2_System.GETCURTASKINDEX;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[AreAllTestsFinished := FALSE;
 
@@ -163,8 +167,8 @@ END_IF]]></ST>
 *)
 METHOD PUBLIC AssertArray2dEquals_LREAL
 VAR_IN_OUT
-    Expecteds : ARRAY[*,*] OF LREAL; // LREAL 2d array with expected values
-    Actuals : ARRAY[*,*] OF LREAL; // LREAL 2d array with actual values
+    Expecteds : ARRAY[*, *] OF LREAL; // LREAL 2d array with expected values
+    Actuals : ARRAY[*, *] OF LREAL; // LREAL 2d array with actual values
 END_VAR
 VAR_INPUT
     Delta : LREAL; // The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell
@@ -189,7 +193,8 @@ VAR
     ActualArrayIndex : ARRAY[1..2] OF DINT; // Array of current Actual array indexes when looping through arrays
     Expected : LREAL; // Single expected value
     Actual : LREAL; // Single actual value
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -317,8 +322,8 @@ END_IF]]></ST>
 *)
 METHOD PUBLIC AssertArray2dEquals_REAL
 VAR_IN_OUT
-    Expecteds : ARRAY[*,*] OF REAL; // REAL 2d array with expected values
-    Actuals : ARRAY[*,*] OF REAL; // REAL 2d array with actual values
+    Expecteds : ARRAY[*, *] OF REAL; // REAL 2d array with expected values
+    Actuals : ARRAY[*, *] OF REAL; // REAL 2d array with actual values
 END_VAR
 VAR_INPUT
     Delta : REAL; // The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell
@@ -343,7 +348,8 @@ VAR
     ActualArrayIndex : ARRAY[1..2] OF DINT; // Array of current Actual array indexes when looping through arrays
     Expected : REAL; // Single expected value
     Actual : REAL; // Single actual value
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -471,8 +477,8 @@ END_IF]]></ST>
 *)
 METHOD PUBLIC AssertArray3dEquals_LREAL
 VAR_IN_OUT
-    Expecteds : ARRAY[*,*,*] OF LREAL; // LREAL 3d array with expected values
-    Actuals : ARRAY[*,*,*] OF LREAL; // LREAL 3d array with actual values
+    Expecteds : ARRAY[*, *, *] OF LREAL; // LREAL 3d array with expected values
+    Actuals : ARRAY[*, *, *] OF LREAL; // LREAL 3d array with actual values
 END_VAR
 VAR_INPUT
     Delta : LREAL; // The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell
@@ -485,7 +491,7 @@ VAR
     ActualString : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
     TestInstancePath : Tc2_System.T_MaxString;
-    DimensionIndex : USINT;  // Index when looping through Dimensions
+    DimensionIndex : USINT; // Index when looping through Dimensions
     LowerBoundExpecteds : ARRAY[1..3] OF DINT; // Lower bounds of Expecteds array in each dimension
     UpperBoundExpecteds : ARRAY[1..3] OF DINT; // Upper bounds of Expecteds array in each dimension
     LowerBoundActuals : ARRAY[1..3] OF DINT; // Lower bounds of Actuals array in each dimension
@@ -497,7 +503,8 @@ VAR
     ActualArrayIndex : ARRAY[1..3] OF DINT; // Array of current Actual array indexes when looping through arrays
     Expected : LREAL; // Single expected value
     Actual : LREAL; // Single actual value
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -652,8 +659,8 @@ END_IF]]></ST>
 *)
 METHOD PUBLIC AssertArray3dEquals_REAL
 VAR_IN_OUT
-    Expecteds : ARRAY[*,*,*] OF REAL; // REAL 3d array with expected values
-    Actuals : ARRAY[*,*,*] OF REAL; // REAL 3d array with actual values
+    Expecteds : ARRAY[*, *, *] OF REAL; // REAL 3d array with expected values
+    Actuals : ARRAY[*, *, *] OF REAL; // REAL 3d array with actual values
 END_VAR
 VAR_INPUT
     Delta : REAL; // The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell
@@ -666,7 +673,7 @@ VAR
     ActualString : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
     TestInstancePath : Tc2_System.T_MaxString;
-    DimensionIndex : USINT;  // Index when looping through Dimensions
+    DimensionIndex : USINT; // Index when looping through Dimensions
     LowerBoundExpecteds : ARRAY[1..3] OF DINT; // Lower bounds of Expecteds array in each dimension
     UpperBoundExpecteds : ARRAY[1..3] OF DINT; // Upper bounds of Expecteds array in each dimension
     LowerBoundActuals : ARRAY[1..3] OF DINT; // Lower bounds of Actuals array in each dimension
@@ -681,7 +688,8 @@ VAR
     ExpectedValueString : Tc2_System.T_MaxString;
     ActualValueString : Tc2_System.T_MaxString;
     FormatString : Tc2_Utilities.FB_FormatString; // String formatter for output messages
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -854,7 +862,8 @@ VAR
     SizeOfActuals : DINT;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -946,7 +955,8 @@ VAR
     ActualByteString : STRING;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -1045,7 +1055,8 @@ VAR
     SizeOfActuals : DINT;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -1137,7 +1148,8 @@ VAR
     ActualDWordString : STRING;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -1235,7 +1247,8 @@ VAR
     SizeOfActuals : DINT;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -1325,7 +1338,8 @@ VAR
     SizeOfActuals : DINT;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -1416,7 +1430,8 @@ VAR
     SizeOfActuals : DINT;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -1508,7 +1523,8 @@ VAR
     ActualLWordString : STRING;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -1607,7 +1623,8 @@ VAR
     SizeOfActuals : DINT;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -1697,7 +1714,8 @@ VAR
     SizeOfActuals : DINT;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -1787,7 +1805,8 @@ VAR
     SizeOfActuals : DINT;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -1878,7 +1897,8 @@ VAR
     SizeOfActuals : DINT;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -1968,7 +1988,8 @@ VAR
     SizeOfActuals : DINT;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -2058,7 +2079,8 @@ VAR
     SizeOfActuals : DINT;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -2150,7 +2172,8 @@ VAR
     ActualDWordString : STRING;
     ExpectedsIndex : DINT;
     ActualsIndex : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -2242,7 +2265,7 @@ VAR
     ActualDataString : Tc2_System.T_MaxString;
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-
+    
     boolExpected : BOOL;
     boolActual : BOOL;
     byteExpected : BYTE;
@@ -2287,13 +2310,14 @@ VAR
     usintActual : USINT;
     wordExpected : WORD;
     wordActual : WORD;
-
+    
     (* ANY comparison variables *)
     DataTypesNotEquals : BOOL; // The data type of the two ANY input parameters are not equal
     DataSizeNotEquals : BOOL; // The data size of the two ANY input parameters are not equal
     DataContentNotEquals : BOOL; // The data content of the two ANY input parameters are not equal
     IteratorCounter : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -2604,7 +2628,8 @@ END_VAR
 VAR
     AlreadyReported : BOOL;
     TestInstancePath : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -2646,7 +2671,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -2696,7 +2722,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -2738,7 +2765,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -2780,7 +2808,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -2822,7 +2851,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -2872,7 +2902,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -2914,7 +2945,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -2957,7 +2989,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -2999,7 +3032,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -3041,7 +3075,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -3086,13 +3121,14 @@ METHOD PUBLIC AssertEquals_REAL
 VAR_INPUT
     Expected : REAL; // REAL expected value
     Actual : REAL; // REAL actual value
-    Delta : REAL;  // The maximum delta between the absolute value of expected and actual for which both numbers are still considered equal
+    Delta : REAL; // The maximum delta between the absolute value of expected and actual for which both numbers are still considered equal
     Message : Tc2_System.T_MaxString; // The identifying message for the assertion error
 END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -3134,7 +3170,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -3176,7 +3213,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -3218,7 +3256,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -3260,7 +3299,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -3302,7 +3342,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -3344,7 +3385,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -3386,7 +3428,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -3428,7 +3471,8 @@ END_VAR
 VAR
     AlreadyReported : BOOL;
     TestInstancePath : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -3470,7 +3514,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -3520,7 +3565,8 @@ END_VAR
 VAR
     TestInstancePath : Tc2_System.T_MaxString;
     AlreadyReported : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF GVL_TcUnit.IgnoreCurrentTest OR GVL_TcUnit.CurrentTestIsFinished THEN
     RETURN;
@@ -3557,7 +3603,8 @@ METHOD PUBLIC AssertFalse
 VAR_INPUT
     Condition : BOOL; // Condition to be checked
     Message : Tc2_System.T_MaxString; // The identifying message for the assertion error
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[AssertEquals_BOOL(Expected := FALSE, Actual := Condition, Message := Message);]]></ST>
       </Implementation>
@@ -3570,7 +3617,8 @@ METHOD PUBLIC AssertTrue
 VAR_INPUT
     Condition : BOOL; // Condition to be checked
     Message : Tc2_System.T_MaxString; // The identifying message for the assertion error
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[AssertEquals_BOOL(Expected := TRUE, Actual := Condition, Message := Message);]]></ST>
       </Implementation>
@@ -3587,7 +3635,8 @@ VAR
     NumberOfArrayAsserts : UINT;
     
     IteratorCounter : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[TestInstancePath := AddTestNameToInstancePath(FindTestSuiteInstancePath());
 NumberOfAsserts := AssertResults.GetNumberOfAssertsForTest(CompleteTestInstancePath := TestInstancePath);
@@ -3610,8 +3659,9 @@ END_IF]]></ST>
       <Declaration><![CDATA[METHOD FB_init : BOOL
 VAR_INPUT
     bInitRetains : BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
-    bInCopyCode : BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-END_VAR]]></Declaration>
+    bInCopyCode : BOOL; // if TRUE, the instance afterwards gets moved into the copy code (online change)
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[GVL_TcUnit.NumberOfInitializedTestSuites := GVL_TcUnit.NumberOfInitializedTestSuites + 1;    
 GVL_TcUnit.TestSuiteAddresses[GVL_TcUnit.NumberOfInitializedTestSuites] := THIS;]]></ST>
@@ -3619,7 +3669,8 @@ GVL_TcUnit.TestSuiteAddresses[GVL_TcUnit.NumberOfInitializedTestSuites] := THIS;
     </Method>
     <Method Name="FindTestSuiteInstancePath" Id="{e69a4510-81a2-4d65-94e4-52c06ac49944}">
       <Declaration><![CDATA[(* Searches for the instance path of the calling function block *)
-METHOD PRIVATE FindTestSuiteInstancePath : Tc2_System.T_MaxString]]></Declaration>
+METHOD PRIVATE FindTestSuiteInstancePath : Tc2_System.T_MaxString
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[FindTestSuiteInstancePath := GetInstancePath();]]></ST>
       </Implementation>
@@ -3636,7 +3687,8 @@ METHOD PRIVATE FindTestSuiteInstancePath : Tc2_System.T_MaxString]]></Declaratio
 VAR
     Counter : UINT;
     FailedTestsCount : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF NumberOfTests > 0 THEN
     FOR Counter := 1 TO GetNumberOfTests() BY 1 DO
@@ -3654,7 +3706,8 @@ GetNumberOfFailedTests := FailedTestsCount;]]></ST>
 VAR
     Counter : UINT;
     SkippedTestsCount : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF NumberOfTests > 0 THEN
     FOR Counter := 1 TO GetNumberOfTests() BY 1 DO
@@ -3668,13 +3721,15 @@ GetNumberOfSkippedTests := SkippedTestsCount;]]></ST>
       </Implementation>
     </Method>
     <Method Name="GetNumberOfSuccessfulTests" Id="{635213dc-96ca-4be6-9c0d-c0454c29d34d}">
-      <Declaration><![CDATA[METHOD PUBLIC GetNumberOfSuccessfulTests : UINT]]></Declaration>
+      <Declaration><![CDATA[METHOD PUBLIC GetNumberOfSuccessfulTests : UINT
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[GetNumberOfSuccessfulTests := GetNumberOfTests() - GetNumberOfFailedTests() - GetNumberOfSkippedTests();]]></ST>
       </Implementation>
     </Method>
     <Method Name="GetNumberOfTests" Id="{6f67c6d5-c29e-4577-8651-51bd6db3ab63}">
-      <Declaration><![CDATA[METHOD PUBLIC GetNumberOfTests : UINT]]></Declaration>
+      <Declaration><![CDATA[METHOD PUBLIC GetNumberOfTests : UINT
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[GetNumberOfTests := NumberOfTests;]]></ST>
       </Implementation>
@@ -3684,7 +3739,8 @@ GetNumberOfSkippedTests := SkippedTestsCount;]]></ST>
 METHOD PUBLIC GetTestByPosition : FB_Test
 VAR_INPUT
     Position : UINT(1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite);
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[GetTestByPosition := Tests[Position];]]></ST>
       </Implementation>
@@ -3696,7 +3752,8 @@ VAR_INPUT
 END_VAR
 VAR
     IteratorCounter : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IsTestFinished := FALSE;
 IF NumberOfTests > 0 THEN
@@ -3717,7 +3774,8 @@ VAR_INPUT
 END_VAR
 VAR
     IteratorCounter : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF NumberOfTests > 0 THEN
     FOR IteratorCounter := 1 TO NumberOfTests BY 1 DO
@@ -3734,13 +3792,14 @@ END_IF]]></ST>
       <Declaration><![CDATA[(* Marks the test as finished in this testsuite.
    Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
 *)
-METHOD PUBLIC SetTestFinished : BOOL;
+METHOD PUBLIC SetTestFinished : BOOL
 VAR_INPUT
     TestName : Tc2_System.T_MaxString;
 END_VAR
 VAR
     IteratorCounter : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF NumberOfTests > 0 THEN
     FOR IteratorCounter := 1 TO NumberOfTests BY 1 DO

--- a/TcUnit/TcUnit/POUs/FB_XmlControl.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_XmlControl.TcPOU
@@ -14,9 +14,9 @@ VAR
     TagsSeek : STRING;
     TagBuffer : FB_StreamBuffer;
     Tag : Tc2_System.T_MaxString;
-    TagOpen: BOOL;
+    TagOpen : BOOL;
     Select : UDINT;
-    SearchPosition : UDINT; 
+    SearchPosition : UDINT;
 END_VAR
 VAR CONSTANT
     TAG_OPEN : STRING(1) := '<';
@@ -31,7 +31,7 @@ VAR CONSTANT
     CLOSE_COMMENT : STRING(4) := ' -->';
     TAB : STRING(2) := '$T';
     CR_LF : STRING(4) := '$R$N';
-
+    
     // $OD : ASCII code for carriage return (CR)
     // $$ : to add a $R
     // $' : to add ' (apostrophe)
@@ -39,7 +39,8 @@ VAR CONSTANT
     // $N or $n : new line
     // $P or $p : next page
     // $R or $r : end of line
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>
@@ -47,7 +48,8 @@ END_VAR]]></Declaration>
       <Declaration><![CDATA[(* 
     Clears the contents of the entire buffer.
 *)
-METHOD PUBLIC ClearBuffer]]></Declaration>
+METHOD PUBLIC ClearBuffer
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[SearchPosition := 0;
 TagListSeekBuffer.Length := 0;
@@ -61,12 +63,13 @@ Tag := '';]]></ST>
     Closes a Tag:
     XML: <MyTag />'
 
-    Method: XML.CloseTag();
+Method : XML.CloseTag();
 *)
 METHOD PUBLIC CloseTag : Tc2_System.T_MaxString
 VAR
     ClosedTag : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF TagOpen THEN
     XmlBuffer.Append := END_TAG_CLOSE;
@@ -85,7 +88,8 @@ CloseTag := ClosedTag;]]></ST>
       </Implementation>
     </Method>
     <Property Name="Length" Id="{4fdf30b6-5fe7-4452-ad0a-85e866e236d0}">
-      <Declaration><![CDATA[PROPERTY Length : UDINT]]></Declaration>
+      <Declaration><![CDATA[PROPERTY Length : UDINT
+]]></Declaration>
       <Get Name="Get" Id="{267105d4-b124-4c5c-a359-0434c4992afc}">
         <Declaration><![CDATA[]]></Declaration>
         <Implementation>
@@ -103,7 +107,8 @@ CloseTag := ClosedTag;]]></ST>
 METHOD PUBLIC NewComment
 VAR_INPUT
     Comment : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF TagOpen THEN
     XmlBuffer.Append := TAG_CLOSE;
@@ -124,7 +129,8 @@ METHOD PUBLIC NewParameter
 VAR_INPUT
     Name : Tc2_System.T_MaxString;
     Value : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[XmlBuffer.Append := SPACE;
 XmlBuffer.Append := Name;
@@ -144,7 +150,8 @@ XmlBuffer.Append := QUOTE;]]></ST>
 METHOD PUBLIC NewTag
 VAR_INPUT
     Name : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF TagOpen THEN
     XmlBuffer.Append := TAG_CLOSE;
@@ -160,7 +167,8 @@ TagListBuffer.Append := Name;]]></ST>
       <Declaration><![CDATA[METHOD PUBLIC NewTagData
 VAR_INPUT
     Data : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[XmlBuffer.Append := TAG_CLOSE;
 XmlBuffer.Append := Data;
@@ -172,7 +180,8 @@ TagOpen := FALSE;]]></ST>
 VAR_INPUT
     PointerToBuffer : POINTER TO BYTE; // ADR(..)
     SizeOfBuffer : UDINT; // SIZEOF(..)
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[XmlBuffer.SetBuffer(PointerToBufferAddress:= PointerToBuffer, SizeOfBuffer := SizeOfBuffer);
 TagListBuffer.SetBuffer(PointerToBufferAddress := ADR(Tags), SizeOfBuffer := SIZEOF(Tags));
@@ -185,7 +194,8 @@ TagBuffer.SetBuffer(PointerToBufferAddress := ADR(Tag), SizeOfBuffer := SIZEOF(T
     Jump to the beginning of the XML data
     XML.ToStartBuffer();
 *)
-METHOD PUBLIC ToStartBuffer]]></Declaration>
+METHOD PUBLIC ToStartBuffer
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[SearchPosition := 0;
 TagListSeekBuffer.Length := 0;
@@ -197,7 +207,7 @@ Tag := '';]]></ST>
       <Declaration><![CDATA[(*
     Add your own preffered fileheader like:
     XML: <?xml version="1.0" encoding="UTF-8"?>
-    
+
     Start with calling this method before appending any other tags!
 
     XML.WriteDocumentHeader('<?xml version="1.0" encoding="UTF-8"?>');
@@ -205,7 +215,8 @@ Tag := '';]]></ST>
 METHOD PUBLIC WriteDocumentHeader
 VAR_INPUT
     Header : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[XmlBuffer.Append := Header;]]></ST>
       </Implementation>

--- a/TcUnit/TcUnit/POUs/FB_XmlControl.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_XmlControl.TcPOU
@@ -63,7 +63,7 @@ Tag := '';]]></ST>
     Closes a Tag:
     XML: <MyTag />'
 
-Method : XML.CloseTag();
+    Method : XML.CloseTag();
 *)
 METHOD PUBLIC CloseTag : Tc2_System.T_MaxString
 VAR

--- a/TcUnit/TcUnit/POUs/FB_xUnitXmlPublisher.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_xUnitXmlPublisher.TcPOU
@@ -8,17 +8,18 @@ FUNCTION_BLOCK FB_xUnitXmlPublisher IMPLEMENTS I_TestResultLogger
 VAR
     // Dependancy Injection via FB_Init
     TestResults : I_TestResults;
-
+    
     // File access mode
     AccessMode : SysFile.ACCESS_MODE := SysFile.AM_WRITE_PLUS;
-
+    
     File : FB_FileControl;
     Xml : FB_XMLControl;
     BufferInitialised : BOOL := FALSE;
     Buffer : ARRAY [0..(GVL_Param_TcUnit.XUnitBufferSize - 1)] OF BYTE;
     WritingTestSuiteResultNumber : UINT(1..GVL_Param_TcUnit.MaxNumberOfTestSuites);
     PublishTrigger : Tc2_Standard.R_TRIG;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>
@@ -27,7 +28,8 @@ END_VAR]]></Declaration>
     Deletes the former file (if it exists).
     Opens the file, writes the buffer and closes it.
 *)
-METHOD PRIVATE DeleteOpenWriteClose : SysFile.SysTypes.RTS_IEC_RESULT;]]></Declaration>
+METHOD PRIVATE DeleteOpenWriteClose : SysFile.SysTypes.RTS_IEC_RESULT
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[DeleteOpenWriteClose := SysDir.CmpErrors.Errors.ERR_OK;   
 IF Initialised() THEN
@@ -47,12 +49,13 @@ END_IF;]]></ST>
     methods explicitly and provide additional code there with the standard initialization
     code. You can evaluate the return value.
 *)
-METHOD FB_Init: BOOL
+METHOD FB_Init : BOOL
 VAR_INPUT
-    bInitRetains: BOOL; // TRUE: the retain variables are initialized (reset warm / reset cold)
-    bInCopyCode: BOOL;  // TRUE: the instance will be copied to the copy code afterward (online change)
+    bInitRetains : BOOL; // TRUE: the retain variables are initialized (reset warm / reset cold)
+    bInCopyCode : BOOL; // TRUE: the instance will be copied to the copy code afterward (online change)
     iTestResults : I_TestResults; // Interface dependency injection
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Set buffer and flag
 Xml.SetBuffer(PointerToBuffer := ADR(Buffer), SizeOfBuffer := SIZEOF(Buffer));
@@ -65,7 +68,8 @@ TestResults := iTestResults;]]></ST>
       </Implementation>
     </Method>
     <Method Name="Initialised" Id="{dac11801-83e2-4726-b3a7-dcd7f73621e3}">
-      <Declaration><![CDATA[METHOD PRIVATE Initialised : BOOL]]></Declaration>
+      <Declaration><![CDATA[METHOD PRIVATE Initialised : BOOL
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[Initialised := THIS^.BufferInitialised;]]></ST>
       </Implementation>
@@ -74,7 +78,7 @@ TestResults := iTestResults;]]></ST>
       <Declaration><![CDATA[(*
     This method is responsible for the entire generation of the output file. 
     The output of the xml writer is NOT beautified.
-    
+
     When new data is available, feel free to add it to the report
 *)
 METHOD PUBLIC LogTestSuiteResults
@@ -87,7 +91,8 @@ VAR CONSTANT
     TEST_STATUS_SKIP : STRING := 'SKIP';
     TEST_STATUS_PASS : STRING := 'PASS';
     TEST_STATUS_FAIL : STRING := 'FAIL';
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
         <ST><![CDATA[UnitTestResults REF=TestResults.GetTestSuiteResults();
 

--- a/TcUnit/TcUnit/POUs/Functions/F_AnyToUnionValue.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/F_AnyToUnionValue.TcPOU
@@ -6,7 +6,8 @@ VAR_INPUT
     AnySize : UDINT;
     AnyTypeClass : IBaseLibrary.TypeClass;
     AnyValue : POINTER TO BYTE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[CASE AnyTypeClass OF
     IBaseLibrary.TypeClass.TYPE_BOOL :

--- a/TcUnit/TcUnit/POUs/Functions/F_AnyTypeClassToString.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/F_AnyTypeClassToString.TcPOU
@@ -7,7 +7,8 @@
 FUNCTION F_AnyTypeClassToString : STRING
 VAR_INPUT
     AnyTypeClass : __SYSTEM.TYPE_CLASS;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[CASE UDINT_TO_INT(AnyTypeClass) OF
     IBaseLibrary.TypeClass.TYPE_BOOL :

--- a/TcUnit/TcUnit/POUs/Functions/F_AssertionTypeToString.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/F_AssertionTypeToString.TcPOU
@@ -6,7 +6,8 @@
 FUNCTION F_AssertionTypeToString : Tc2_System.T_MaxString
 VAR_INPUT
     AssertionType : E_AssertionType;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[CASE AssertionType OF
     E_AssertionType.Type_UNDEFINED :

--- a/TcUnit/TcUnit/POUs/Functions/F_GetTestSuiteNameFromTestInstancePath.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/F_GetTestSuiteNameFromTestInstancePath.TcPOU
@@ -8,7 +8,8 @@ END_VAR
 VAR
     TestSuiteName : Tc2_System.T_MaxString;
     FindPosition : INT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[TestSuiteName := F_RemoveInstancePathAndProjectNameFromTestInstancePath(TestInstancePath := TestInstancePath);
 (* Remove everything except the test suite name *)

--- a/TcUnit/TcUnit/POUs/Functions/F_IsAnyEqualToUnionValue.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/F_IsAnyEqualToUnionValue.TcPOU
@@ -10,7 +10,8 @@ VAR_INPUT
 END_VAR
 VAR
     AnyExpectedOrActual : U_ExpectedOrActual;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[AnyExpectedOrActual := F_AnyToUnionValue(AnySize := ExpectedOrActualSize,
                                          AnyTypeClass := ExpectedOrActualTypeClass,

--- a/TcUnit/TcUnit/POUs/Functions/F_RemoveInstancePathAndProjectNameFromTestInstancePath.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/F_RemoveInstancePathAndProjectNameFromTestInstancePath.TcPOU
@@ -8,7 +8,8 @@ END_VAR
 VAR
     CharacterPositionOfProjectName : INT;
     ProjectNameWithDot : Tc2_System.T_MaxString;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[(* Add the '.' character to the project name for search *)
 ProjectNameWithDot := Tc2_Standard.CONCAT(STR1 := TwinCAT_SystemInfoVarList._AppInfo.ProjectName, STR2 := '.');

--- a/TcUnit/TcUnit/POUs/Functions/IS_TEST_FINISHED.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/IS_TEST_FINISHED.TcPOU
@@ -9,7 +9,8 @@ END_VAR
 VAR
     Counter : UINT;
     CurrentTest : FB_Test;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[IS_TEST_FINISHED := FALSE;
 

--- a/TcUnit/TcUnit/POUs/Functions/RUN.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/RUN.TcPOU
@@ -4,7 +4,8 @@
     <Declaration><![CDATA[(*
     This function runs all test suites that have been initialized.
 *)
-FUNCTION RUN]]></Declaration>
+FUNCTION RUN
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[GVL_TcUnit.TcUnitRunner.RunTestSuiteTests();]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/TEST.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/TEST.TcPOU
@@ -10,7 +10,8 @@ VAR_INPUT
 END_VAR
 VAR
     CounterTestSuiteAddress : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[(* Mark this test as the current one being executed *)
 GVL_TcUnit.CurrentTestNameBeingCalled := TestName;

--- a/TcUnit/TcUnit/POUs/Functions/TEST_FINISHED.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/TEST_FINISHED.TcPOU
@@ -6,7 +6,8 @@ FUNCTION TEST_FINISHED : BOOL
 VAR
     TestName : Tc2_System.T_MaxString;
     Counter : UINT := 0;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[// Grab the currently running test name
 TestName := GVL_TcUnit.CurrentTestNameBeingCalled;

--- a/TcUnit/TcUnit/POUs/Functions/TEST_FINISHED_NAMED.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/TEST_FINISHED_NAMED.TcPOU
@@ -17,7 +17,8 @@ VAR_STAT
 END_VAR
 VAR CONSTANT
     MaxNumberOfNonExistentTestNamesFailedLookups : UINT := 3;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[(* Find the test suite and:
    1. Set the test in that test suite as finished

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_BOOL.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_BOOL.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO BOOL;
     Value : BOOL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_BYTE.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_BYTE.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO BYTE;
     Value : BYTE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_DATE.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_DATE.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO DATE;
     Value : DATE;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_DATE_AND_TIME.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_DATE_AND_TIME.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO DATE_AND_TIME;
     Value : DATE_AND_TIME;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_DINT.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_DINT.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO DINT;
     Value : DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_DWORD.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_DWORD.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO DWORD;
     Value : DWORD;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_INT.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_INT.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO INT;
     Value : INT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_LINT.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_LINT.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO LINT;
     Value : LINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_LREAL.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_LREAL.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO LREAL;
     Value : LREAL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_LWORD.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_LWORD.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO LWORD;
     Value : LWORD;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_REAL.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_REAL.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO REAL;
     Value : REAL;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_SINT.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_SINT.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO SINT;
     Value : SINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_STRING.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_STRING.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO STRING;
     Value : STRING;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_TIME.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_TIME.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO TIME;
     Value : TIME;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_TIME_OF_DAY.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_TIME_OF_DAY.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO TIME_OF_DAY;
     Value : TIME_OF_DAY;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_UDINT.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_UDINT.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO UDINT;
     Value : UDINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_UINT.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_UINT.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO UINT;
     Value : UINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_ULINT.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_ULINT.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO ULINT;
     Value : ULINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_USINT.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_USINT.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO USINT;
     Value : USINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_WORD.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_WORD.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO WORD;
     Value : WORD;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>

--- a/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_WSTRING.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/WRITE_PROTECTED_/WRITE_PROTECTED_WSTRING.TcPOU
@@ -5,7 +5,8 @@
 VAR_INPUT
     Ptr : POINTER TO WSTRING;
     Value : WSTRING;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
     <Implementation>
       <ST><![CDATA[Ptr^ := Value;]]></ST>
     </Implementation>


### PR DESCRIPTION
I just released a new version of _TcBlack_ and ran it on your project. Thought you might like (some of) the changes it made to _TcUnit_. 

You can also run it yourself of course. [Download](https://github.com/Roald87/TcBlack/releases/tag/v0.2.0) the release and use 

```
> TcBlack.exe --indentation "    " --safe -p C:\Users\roald\Source\Repos\TcUnit\TcUnit-Verifier\TcUnit-Verifier_TwinCAT\TcUnit-Verifier_TwinCAT\TcUnitVerifier\TcUnitVerifier.plcproj
> TcBlack.exe --indentation "    " --safe -p C:\Users\roald\Source\Repos\TcUnit\TcUnit\TcUnitTcUnit.plcproj
```


Most of the changes are an added new line to make sure that `]]></Declaration>` is always on a new line. For the declaration part this usually doesn't matter (since it usually ends with `END_VAR`), but for the implementation part it will. Unfortunately formatting of the implementation is not supported yet.

Other changes include:
- Removal of trailing spaces, e.g. diffs of `FB_AdjustAssertFailureMessageToMax253CharLengthTest.TcPOU`
- White lines have equal indentation as the surrounding code, e.g. diffs of `FB_AdjustAssertFailureMessageToMax253CharLengthTest.TcPOU`
- Added spaces after commas in arrays, e.g. diffs of `FB_AssertEveryFailedTestTwiceArrayVersion.TcPOU`
- Removed spaces around `:=` inside a initialization, e.g. diffs of `TFB_MultipleAssertWithSameParametersInDifferentCyclesAndInSameTest.TcPOU`
- Replaced tab indent with spaces, e.g. diffs of `FB_AdsTestResultLogger.TcPOU`
- Removed trailing `;` in method declaration, e.g. `FB_FileControl.TcPOU`
