### PR TITLE
Added a time delay to RUN_IN_SEQUENCE() (Issue #95) + solved issue #128

### DIFF
--- a/TcUnit/TcUnit/POUs/FB_AdsTestResultLogger.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_AdsTestResultLogger.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.4">
   <POU Name="FB_AdsTestResultLogger" Id="{d14d6247-3ce3-459f-be22-6ee3520279ed}" SpecialFunc="None">
     <Declaration><![CDATA[(*
     This function block reports the results from the tests using the built-in ADSLOGSTR functionality
@@ -120,9 +120,15 @@ IF PrintingTestSuiteResultNumber <= GVL_TcUnit.NumberOfInitializedTestSuites AND
                                                     StrArg := F_AssertionTypeToString(AssertionType :=
                                                         TcUnitTestResults.TestSuiteResults[PrintingTestSuiteResultNumber].TestCaseResults[TestsInTestSuiteCounter].FailureType));
             END_IF
-
 		END_FOR
 
+		(* Print Error if there are too many tests in the Test Suite*)
+        IF (TcUnitTestResults.TestSuiteResults[PrintingTestSuiteResultNumber].NumberOfTests > GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite) THEN
+            GVL_TcUnit.AdsMessageQueue.WriteLog(MsgCtrlMask := Tc2_System.ADSLOG_MSGTYPE_ERROR,
+                                                MsgFmtStr := '| Tests failed because = %s',
+                                                StrArg := concat (TO_STRING(TcUnitTestResults.TestSuiteResults[PrintingTestSuiteResultNumber].NumberOfTests) ,concat(' in this Test-Suite : ',concat(TcUnitTestResults.TestSuiteResults[PrintingTestSuiteResultNumber].Name, '. It is more as in the GVL_Param_TcUnit configured'))));
+        END_IF		
+		
         IF PrintingTestSuiteResultNumber = GVL_TcUnit.NumberOfInitializedTestSuites THEN
             PrintedTestSuitesResults := TRUE;
         ELSE
@@ -157,5 +163,21 @@ IF (GVL_TcUnit.NumberOfInitializedTestSuites = 0 OR PrintingTestSuiteResultNumbe
 END_IF]]></ST>
       </Implementation>
     </Method>
+    <LineIds Name="FB_AdsTestResultLogger">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_AdsTestResultLogger.FB_init">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_AdsTestResultLogger.LogTestSuiteResults">
+      <LineId Id="3" Count="72" />
+      <LineId Id="77" Count="0" />
+      <LineId Id="120" Count="0" />
+      <LineId Id="122" Count="4" />
+      <LineId Id="78" Count="0" />
+      <LineId Id="121" Count="0" />
+      <LineId Id="79" Count="30" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/TcUnit/TcUnit/POUs/FB_TcUnitRunner.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_TcUnitRunner.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.4">
   <POU Name="FB_TcUnitRunner" Id="{857e16d6-a26c-468a-935e-aa7317c263b9}" SpecialFunc="None">
     <Declaration><![CDATA[(*
     This function block is responsible for holding track of the tests and executing them.
@@ -90,6 +90,9 @@ GVL_TcUnit.AdsMessageQueue();]]></ST>
     <Method Name="RunTestSuiteTestsInSequence" Id="{01bbc2d3-b1c5-4bce-a3f3-fa46a50fd167}">
       <Declaration><![CDATA[(* This runs all the test suites in sequence (one after the other) *)
 METHOD INTERNAL RunTestSuiteTestsInSequence
+VAR_INPUT
+	DelayTime	:TIME;		// Time delay between a Test-Suite is finished and the next Test-Suite starts
+END_VAR
 VAR
     BusyPrinting : BOOL;
     (* We need to hold a temporary state of the statistics 
@@ -102,19 +105,25 @@ VAR_INST
     (* This variable holds which current test suite is being called, as we are running
        each one in a sequence (one by one) *)
      CurrentlyRunningTestSuite : UINT := 1;
+	 TofDelayTime			   : Tc2_Standard.TOF;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[(* Run TcUnit test suites *)
+        <ST><![CDATA[TofDelayTime(PT:=DelayTime);
+(* Run TcUnit test suites *)
 IF NOT AllTestSuitesFinished THEN
     IF GVL_TcUnit.NumberOfInitializedTestSuites = 0 THEN
         AllTestSuitesFinished := TRUE;
     ELSIF GVL_TcUnit.NumberOfInitializedTestSuites > 0 THEN
+		IF TofDelayTime.Q THEN
+			TofDelayTime.IN := FALSE;
+		END_IF
         IF GVL_TcUnit.TestSuiteAddresses[CurrentlyRunningTestSuite]^.AreAllTestsFinished() THEN
             IF CurrentlyRunningTestSuite <> GVL_TcUnit.NumberOfInitializedTestSuites THEN
                 NumberOfTestSuitesFinished := NumberOfTestSuitesFinished + 1;
                 CurrentlyRunningTestSuite := CurrentlyRunningTestSuite + 1;
+				TofDelayTime.IN := TRUE;
             END_IF
-        ELSE
+        ELSIF NOT TofDelayTime.Q THEN
             GVL_TcUnit.CurrentTestSuiteBeingCalled := GVL_TcUnit.TestSuiteAddresses[CurrentlyRunningTestSuite];
             GVL_TcUnit.CurrentTestSuiteBeingCalled^.SetHasStartedRunning();
             GVL_TcUnit.CurrentTestSuiteBeingCalled^();
@@ -143,5 +152,19 @@ XmlTestResultPublisher.LogTestSuiteResults();
 GVL_TcUnit.AdsMessageQueue();]]></ST>
       </Implementation>
     </Method>
+    <LineIds Name="FB_TcUnitRunner">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TcUnitRunner.AbortRunningTestSuiteTests">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TcUnitRunner.RunTestSuiteTests">
+      <LineId Id="3" Count="34" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TcUnitRunner.RunTestSuiteTestsInSequence">
+      <LineId Id="90" Count="40" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/TcUnit/TcUnit/POUs/FB_TestSuite.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_TestSuite.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.4">
   <POU Name="FB_TestSuite" Id="{f80c23f2-119d-406b-ae11-06d1991bf64d}" SpecialFunc="None">
     <Declaration><![CDATA[(* This function block is responsible for holding the internal state of the test suite.
    Every test suite can have one or more tests, and every test can do one or more asserts.
@@ -139,14 +139,21 @@ AddTestNameToInstancePath := Tc2_Utilities.CONCAT(STR1 := CompleteTestInstancePa
 VAR
     Counter : UINT;
     GetCurTaskIndex : Tc2_System.GETCURTASKINDEX;
+	TestToAnalyse: UINT;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[AreAllTestsFinished := FALSE;
 
 IF NumberOfTests > 0 THEN
     AreAllTestsFinished := TRUE;
-    (* A test is considered finished if it is finished running (i.e. set by TEST_FINISHED) or if it is skipped/disabled *)
-    FOR Counter := 1 TO GetNumberOfTests() BY 1 DO
+	(*Limit the test analyse to the max array limit of 'Tests[]'*)
+	IF GetNumberOfTests() >  GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite THEN
+		TestToAnalyse := GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite;
+	ELSE
+		TestToAnalyse := GetNumberOfTests();
+	END_IF
+	(* A test is considered finished if it is finished running (i.e. set by TEST_FINISHED) or if it is skipped/disabled *)
+    FOR Counter := 1 TO TestToAnalyse BY 1 DO
         AreAllTestsFinished := AreAllTestsFinished AND (Tests[Counter].IsFinished() OR Tests[Counter].IsSkipped());
     END_FOR
 END_IF
@@ -3768,5 +3775,250 @@ END_VAR]]></Declaration>
 END_IF]]></ST>
       </Implementation>
     </Method>
+    <LineIds Name="FB_TestSuite">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AddTest">
+      <LineId Id="3" Count="57" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AddTestNameToInstancePath">
+      <LineId Id="3" Count="0" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AreAllTestsFinished">
+      <LineId Id="3" Count="3" />
+      <LineId Id="28" Count="0" />
+      <LineId Id="22" Count="1" />
+      <LineId Id="25" Count="0" />
+      <LineId Id="27" Count="0" />
+      <LineId Id="24" Count="0" />
+      <LineId Id="29" Count="0" />
+      <LineId Id="8" Count="9" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArray2dEquals_LREAL">
+      <LineId Id="3" Count="116" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArray2dEquals_REAL">
+      <LineId Id="3" Count="116" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArray3dEquals_LREAL">
+      <LineId Id="3" Count="143" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArray3dEquals_REAL">
+      <LineId Id="3" Count="143" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_BOOL">
+      <LineId Id="3" Count="60" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_BYTE">
+      <LineId Id="3" Count="69" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_DINT">
+      <LineId Id="3" Count="60" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_DWORD">
+      <LineId Id="3" Count="68" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_INT">
+      <LineId Id="3" Count="60" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_LINT">
+      <LineId Id="3" Count="60" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_LREAL">
+      <LineId Id="3" Count="60" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_LWORD">
+      <LineId Id="3" Count="68" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_REAL">
+      <LineId Id="3" Count="60" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_SINT">
+      <LineId Id="3" Count="60" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_UDINT">
+      <LineId Id="3" Count="61" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_UINT">
+      <LineId Id="3" Count="60" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_ULINT">
+      <LineId Id="3" Count="60" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_USINT">
+      <LineId Id="3" Count="60" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertArrayEquals_WORD">
+      <LineId Id="3" Count="68" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals">
+      <LineId Id="3" Count="292" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_BOOL">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_BYTE">
+      <LineId Id="3" Count="31" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_DATE">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_DATE_AND_TIME">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_DINT">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_DWORD">
+      <LineId Id="3" Count="31" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_INT">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_LINT">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_LREAL">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_LTIME">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_LWORD">
+      <LineId Id="3" Count="31" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_REAL">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_SINT">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_STRING">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_TIME">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_TIME_OF_DAY">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_UDINT">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_UINT">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_ULINT">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_USINT">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_WORD">
+      <LineId Id="3" Count="31" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertEquals_WSTRING">
+      <LineId Id="3" Count="23" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertFalse">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.AssertTrue">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.CalculateAndSetNumberOfAssertsForTest">
+      <LineId Id="3" Count="13" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.FB_init">
+      <LineId Id="3" Count="0" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.FindTestSuiteInstancePath">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.GetHasStartedRunning">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.GetInstancePath">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.GetNumberOfFailedTests">
+      <LineId Id="3" Count="7" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.GetNumberOfSkippedTests">
+      <LineId Id="3" Count="7" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.GetNumberOfSuccessfulTests">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.GetNumberOfTests">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.GetTestByPosition">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.IsTestFinished">
+      <LineId Id="3" Count="7" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.SetHasStartedRunning">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.SetTestFailed">
+      <LineId Id="3" Count="7" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="FB_TestSuite.SetTestFinished">
+      <LineId Id="3" Count="8" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/TcUnit/TcUnit/POUs/Functions/RUN_IN_SEQUENCE.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/RUN_IN_SEQUENCE.TcPOU
@@ -1,13 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.4">
   <POU Name="RUN_IN_SEQUENCE" Id="{a1bb30cd-f92f-4bab-aa26-6bd18db0fbc1}" SpecialFunc="None">
     <Declaration><![CDATA[(*
     This function runs all test suites that have been initialized.
     The test suites are run in sequence (one after the other).
 *)
-FUNCTION RUN_IN_SEQUENCE]]></Declaration>
+FUNCTION RUN_IN_SEQUENCE
+VAR_INPUT
+	DelayTime	:TIME;		// Time between a Test-Suite is finished and the next Test-Suite starts
+END_VAR]]></Declaration>
     <Implementation>
-      <ST><![CDATA[GVL_TcUnit.TcUnitRunner.RunTestSuiteTestsInSequence();]]></ST>
+      <ST><![CDATA[GVL_TcUnit.TcUnitRunner.RunTestSuiteTestsInSequence(DelayTime:=DelayTime);]]></ST>
     </Implementation>
+    <LineIds Name="RUN_IN_SEQUENCE">
+      <LineId Id="2" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/TcUnit/TcUnit/POUs/Functions/TEST.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/TEST.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.4">
   <POU Name="TEST" Id="{8dd61791-c583-4b5e-b392-3e0ecf487849}" SpecialFunc="None">
     <Declaration><![CDATA[(*
     This function declares a new test (if it has not been already declared in an earlier cycle)
@@ -27,7 +27,13 @@ FOR CounterTestSuiteAddress := 1 TO GVL_TcUnit.NumberOfInitializedTestSuites BY 
         GVL_TcUnit.CurrentTestIsFinished := GVL_TcUnit.TestSuiteAddresses[CounterTestSuiteAddress]^.IsTestFinished(TestName := TestName);
         RETURN;
     END_IF
-END_FOR]]></ST>
+END_FOR
+]]></ST>
     </Implementation>
+    <LineIds Name="TEST">
+      <LineId Id="3" Count="14" />
+      <LineId Id="2" Count="0" />
+      <LineId Id="27" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
// Time delay between a Test-Suite is finished and the next Test-Suite starts

#128 Created an Error log, if a Test Suite has more Tests as the max number of Test is configured in the Global Parameterlist

bug fixed: TcUnit can stop evaluating the results.
Reason: Method AreAllTestsFinished is not set to true
Solution: The evaluation is limited to the maximum number of tests.