### PR TITLE
Update FB_AssertResultStatic.TcPOU

### DIFF
--- a/TcUnit/TcUnit/POUs/FB_AssertResultStatic.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_AssertResultStatic.TcPOU
@@ -49,6 +49,10 @@ END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[TotalAsserts := TotalAsserts + 1;
+IF TotalAssers > GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite THEN
+  ADSLOGSTR( msgCtrlMask := ADSLOG_MSGTYPE_ERROR, msgFmtStr := 'Number of asserts exceeded.', strArg := '');
+  RETURN;
+END_IF
 AssertResults[TotalAsserts].Expected := F_AnyToUnionValue(AnySize := ExpectedSize, AnyTypeClass := ExpectedTypeClass, AnyValue := ExpectedValue);
 AssertResults[TotalAsserts].Actual := F_AnyToUnionValue(AnySize := ActualSize, AnyTypeClass := ActualTypeClass, AnyValue := ActualValue);
 AssertResults[TotalAsserts].Message := Message;


### PR DESCRIPTION
If we exceed GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite it goes out of the array and corrupts the memory.

Code change is not tested, maybe could be done in more appropriate way, didn't dig to deep, it's just a proposition.