### PR TITLE
fix: wrong parameters in left shift when calculation duration

### DIFF
--- a/TcUnit/TcUnit/POUs/Functions/F_GetCpuCounterAs64bit.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/F_GetCpuCounterAs64bit.TcPOU
@@ -11,7 +11,7 @@ VAR_IN_OUT CONSTANT
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[CpuCounter();
-F_GetCpuCounterAs64bit := SHL(32, DWORD_TO_LWORD(CpuCounter.cpuCntHiDW)) + DWORD_TO_LWORD(CpuCounter.cpuCntLoDW);]]></ST>
+F_GetCpuCounterAs64bit := SHL(DWORD_TO_LWORD(CpuCounter.cpuCntHiDW), 32) + DWORD_TO_LWORD(CpuCounter.cpuCntLoDW);]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
Every 429,4967296 seconds => 7.2 minutes the duration of the tests where calculated incorrectly due to a wrong left shift.
To reproduce the bug without the PR:

- start TcUnit-Verifier
- put a breakpoint in `TcUnit.F_GetCpuCounterAs64Bit` 
- wait for `CpuCounter.cpuCntLoDW` to overflows from 4294967296 to 0 (32 bit variable)
- remove the breakpoint
- the duration is wrong
 
This PR closes #226 ... looking forward to the 1.3 release