### PR TITLE
Fix duration measurement on TEST_ORDERED and add unit tests for duration

### DIFF
--- a/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/ErrorList.cs
+++ b/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/ErrorList.cs
@@ -1,6 +1,9 @@
 ﻿using EnvDTE80;
+using System;
+using System.Globalization;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace TcUnit.Verifier
 {
@@ -12,12 +15,22 @@ namespace TcUnit.Verifier
         {
             public string Description;
             public vsBuildErrorLevel ErrorLevel;
+            public DateTime Timestamp;
 
             public Error(ErrorItem item)
             {
                 Description = item.Description.ToUpper();
                 ErrorLevel = item.ErrorLevel;
+                Timestamp = ParseTimestampFromDescription(item.Description);
             }
+        }
+
+        static public DateTime ParseTimestampFromDescription(string description)
+        {
+            string pattern = @"^(.*?)\s+(\d+\s)ms\s+\|";
+            Match match = Regex.Match(description, pattern, RegexOptions.IgnoreCase);
+            var parsedDate = DateTime.Parse(match.Groups[1].Value, CultureInfo.CurrentCulture).AddMilliseconds(double.Parse(match.Groups[2].Value));
+            return parsedDate;
         }
 
         public IEnumerable<Error> AddNew(ErrorItems errorItems)

--- a/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_TestDurationMeasurement.cs
+++ b/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_TestDurationMeasurement.cs
@@ -13,17 +13,17 @@ namespace TcUnit.Verifier
 
         private void TestNamedTest20msDurationMeasuredCorrectly()
         {
-            AssertContainsResultSet("TestNamedTest20msDurationMeasuredCorrectly", "PRG_TEST.TestDurationMeasurement", "FAIL", 1, 0.06, 0.02);
+            AssertContainsResultSet("TestNamedTest20msDurationMeasuredCorrectly", "PRG_TEST.TestDurationMeasurement", "FAIL", 1, 0.02, 0.1);
         }
 
         private void TestOrderedTest30msDurationMeasuredCorrectly()
         {
-            AssertContainsResultSet("TestOrderedTest30msDurationMeasuredCorrectly", "PRG_TEST.TestDurationMeasurement", "FAIL", 1, 0.06, 0.02);
+            AssertContainsResultSet("TestOrderedTest30msDurationMeasuredCorrectly", "PRG_TEST.TestDurationMeasurement", "FAIL", 1, 0.03, 0.1);
         }
 
         private void TestRegularTestDurationMeasuredCorrectly()
         {
-            AssertContainsResultSet("TestRegularTestDurationMeasuredCorrectly", "PRG_TEST.TestDurationMeasurement", "FAIL", 2, 0.0003, 0.0002);
+            AssertContainsResultSet("TestRegularTestDurationMeasuredCorrectly", "PRG_TEST.TestDurationMeasurement", "FAIL", 2, 0.0003, 0.001);
         }
     }
 }

--- a/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_TestDurationMeasurement.cs
+++ b/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_TestDurationMeasurement.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+
+namespace TcUnit.Verifier
+{
+    class FB_TestDurationMeasurement : TestFunctionBlockAssert
+    {
+        public FB_TestDurationMeasurement(IEnumerable<ErrorList.Error> errors, string testFunctionBlockInstance = null) : base(errors, testFunctionBlockInstance)
+        {
+            TestNamedTest20msDurationMeasuredCorrectly();
+            TestOrderedTest30msDurationMeasuredCorrectly();
+            TestRegularTestDurationMeasuredCorrectly();
+        }
+
+        private void TestNamedTest20msDurationMeasuredCorrectly()
+        {
+            AssertContainsResultSet("TestNamedTest20msDurationMeasuredCorrectly", "PRG_TEST.TestDurationMeasurement", "FAIL", 1, 0.06, 0.02);
+        }
+
+        private void TestOrderedTest30msDurationMeasuredCorrectly()
+        {
+            AssertContainsResultSet("TestOrderedTest30msDurationMeasuredCorrectly", "PRG_TEST.TestDurationMeasurement", "FAIL", 1, 0.06, 0.02);
+        }
+
+        private void TestRegularTestDurationMeasuredCorrectly()
+        {
+            AssertContainsResultSet("TestRegularTestDurationMeasuredCorrectly", "PRG_TEST.TestDurationMeasurement", "FAIL", 2, 0.0003, 0.0002);
+        }
+    }
+}

--- a/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/Program.cs
+++ b/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/Program.cs
@@ -182,8 +182,10 @@ namespace TcUnit.Verifier
                 errorList.Where(e => (
                     e.ErrorLevel == vsBuildErrorLevel.vsBuildErrorLevelHigh 
                     || e.ErrorLevel == vsBuildErrorLevel.vsBuildErrorLevelLow)
-                )
+               )
             );
+
+            errors = errors.OrderBy(error => error.Timestamp).ToList();
 
             // Insert the test classes here
             new FB_PrimitiveTypes(errors);

--- a/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/Program.cs
+++ b/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/Program.cs
@@ -18,7 +18,7 @@ namespace TcUnit.Verifier
         private static string tcUnitTargetNetId = "127.0.0.1.1.1";
         private static VisualStudioInstance vsInstance = null;
         private static ILog log = LogManager.GetLogger("TcUnit-Verifier");
-        private static int expectedNumberOfFailedTests = 118; // Update this if you add intentionally failing tests
+        private static int expectedNumberOfFailedTests = 121; // Update this if you add intentionally failing tests
 
         [STAThread]
         static void Main(string[] args)
@@ -208,6 +208,7 @@ namespace TcUnit.Verifier
             new FB_TestStreamBuffer(errors);
             new FB_TestFinishedNamed(errors);
             new FB_TestNumberOfAssertionsCalculation(errors);
+            new FB_TestDurationMeasurement(errors);
             new FB_EmptyAssertionMessage(errors);
             new FB_AssertCountExceedsMaxNumber(errors);
 

--- a/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/TcUnit-Verifier.csproj
+++ b/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/TcUnit-Verifier.csproj
@@ -58,6 +58,7 @@
     <Compile Include="ErrorList.cs" />
     <Compile Include="FB_AssertCountExceedsMaxNumber.cs" />
     <Compile Include="FB_EmptyAssertionMessage.cs" />
+    <Compile Include="FB_TestDurationMeasurement.cs" />
     <Compile Include="FB_TestXmlControl.cs" />
     <Compile Include="FB_TestFileControl.cs" />
     <Compile Include="FB_TestStreamBuffer.cs" />

--- a/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/TestFunctionBlockAssert.cs
+++ b/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/TestFunctionBlockAssert.cs
@@ -160,6 +160,62 @@ namespace TcUnit.Verifier
             }
         }
 
+        protected void AssertContainsResultSet(string testName, string className, string status, int numberOfAsserts, double duration, double durationRange)
+        {
+            var errorMessagePrefix = $"Test suite {_testFunctionBlockInstance} test {testName} ";
+            try
+            {
+                var results = _errors
+                    .Select((e, index) => new { Error = e, Index = index })
+                    .Where(item =>
+                        item.Error.Description.Contains($"| Test name={testName}".ToUpper()) &&
+                        item.Error.ErrorLevel.Equals(vsBuildErrorLevel.vsBuildErrorLevelLow))
+                    .Select(item => _errors.Skip(item.Index).Take(3))
+                    .FirstOrDefault();
+
+
+                if (!results.ElementAt(1).Description.Contains($"| Test class name={className}".ToUpper()))
+                {
+                    log.Info($"{errorMessagePrefix} does not list class name: {className}");
+                    return;
+                }
+
+                string pattern = @"Test status=(?<Status>\w+), number of asserts=(?<Asserts>\d+), duration=(?<Duration>[\d\.e-]+)";
+                Match match = Regex.Match(results.ElementAt(2).Description, pattern, RegexOptions.IgnoreCase);
+
+                if (!match.Success)
+                {
+                    log.Info($"{errorMessagePrefix} does not contain expected result set");
+                    return;
+                }
+
+                var actualStatus = match.Groups["Status"].Value;
+                if (actualStatus != status)
+                {
+                    log.Info($"{errorMessagePrefix} does not have expected status: {actualStatus} != {status}");
+                    return;
+                }
+
+                var actualNumberOfAsserts = int.Parse(match.Groups["Asserts"].Value);
+                if (actualNumberOfAsserts != numberOfAsserts)
+                {
+                    log.Info($"{errorMessagePrefix} does not have expected number of asserts: {actualNumberOfAsserts} != {numberOfAsserts}");
+                    return;
+                }
+
+                var actualDuration = double.Parse(match.Groups["Duration"].Value);
+                if (System.Math.Abs(actualDuration - duration) > durationRange)
+                {
+                    log.Info($"{errorMessagePrefix} does not have expected duration: abs({actualDuration} - {duration}) > {durationRange}");
+                    return;
+                }
+            } 
+            catch 
+            {
+                log.Info($"{errorMessagePrefix} does not contain expected results");
+            }
+        }
+
         protected string CreateFailedTestCommonString(string method)
         {
             string returnString;

--- a/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/TestFunctionBlockAssert.cs
+++ b/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/TestFunctionBlockAssert.cs
@@ -160,7 +160,7 @@ namespace TcUnit.Verifier
             }
         }
 
-        protected void AssertContainsResultSet(string testName, string className, string status, int numberOfAsserts, double duration, double durationRange)
+        protected void AssertContainsResultSet(string testName, string className, string status, int numberOfAsserts, double expectedDuration, double expectedDurationTolerance)
         {
             var errorMessagePrefix = $"Test suite {_testFunctionBlockInstance} test {testName} ";
             try
@@ -204,9 +204,9 @@ namespace TcUnit.Verifier
                 }
 
                 var actualDuration = double.Parse(match.Groups["Duration"].Value);
-                if (System.Math.Abs(actualDuration - duration) > durationRange)
+                if (System.Math.Abs(actualDuration - expectedDuration) > expectedDurationTolerance)
                 {
-                    log.Info($"{errorMessagePrefix} does not have expected duration: abs({actualDuration} - {duration}) > {durationRange}");
+                    log.Info($"{errorMessagePrefix} does not have expected duration: abs({actualDuration} - {expectedDuration}) > {expectedDurationTolerance}");
                     return;
                 }
             } 

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/TcUnitVerifier.plcproj
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/TcUnitVerifier.plcproj
@@ -32,6 +32,9 @@
     <Compile Include="Test\FB_AdjustAssertFailureMessageToMax253CharLengthTest.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Test\FB_TestDurationMeasurement.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Test\FB_AnyPrimitiveTypes.TcPOU">
       <SubType>Code</SubType>
     </Compile>

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestDurationMeasurement.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestDurationMeasurement.TcPOU
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_TestDurationMeasurement" Id="{12ee45bf-3a7d-4e41-a324-1302d89aa59f}" SpecialFunc="None">
+    <Declaration><![CDATA[(* This testsuite tests that durations are calculated correctly by different types of test cases
+    Tests are considered passing if the duration returned is reasonablly close to the expected value.
+*)
+FUNCTION_BLOCK FB_TestDurationMeasurement EXTENDS TcUnit.FB_TestSuite]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[TestNamedTest20msDurationMeasuredCorrectly();
+TestOrderedTest30msDurationMeasuredCorrectly();
+TestRegularTestDurationMeasuredCorrectly();]]></ST>
+    </Implementation>
+    <Method Name="TestOrderedTest30msDurationMeasuredCorrectly" Id="{139af150-7ad8-44c8-898c-2ab768ced5be}">
+      <Declaration><![CDATA[METHOD PRIVATE TestOrderedTest30msDurationMeasuredCorrectly
+VAR_INST
+    DelayTimer : TON;
+    Counter : DINT;
+END_VAR]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[IF TEST_ORDERED('TestOrderedTest30msDurationMeasuredCorrectly') THEN
+    DelayTimer(IN := TRUE, PT := T#30ms);   
+
+    IF delayTimer.Q THEN
+        // Write the approximate duration through an assert message for use by the verifier
+        AssertEquals_LREAL(0, 0.03, 0, 'Duration');
+    
+        TEST_FINISHED();
+    END_IF
+END_IF]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="TestRegularTestDurationMeasuredCorrectly" Id="{47c4b2d9-0773-4b15-a225-f2e9b9db2037}">
+      <Declaration><![CDATA[METHOD TestRegularTestDurationMeasuredCorrectly
+VAR_INST
+    TestExecuted : BOOL;
+    TestStartedAt : LWORD;
+    TestDuration : LREAL;
+    Counter : DINT;
+END_VAR]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[TEST('TestRegularTestDurationMeasuredCorrectly');
+
+IF NOT TestExecuted THEN
+    // Introduce a delay and store the time it takes for evaluation by the test
+    // use an assert statement as the delay because it takes quite a bit of time
+    // double the value to account for the second assert which will print the message
+    TestStartedAt := F_GetCpuCounterAs64bit(GVL_TcUnit.GetCpuCounter);
+    AssertEquals_LREAL(0, 10, 0, 'Duration for calculation'); 
+    TestDuration := LWORD_TO_LREAL(F_GetCpuCounterAs64bit(GVL_TcUnit.GetCpuCounter) - TestStartedAt) * GVL_TcUnit.HundredNanosecondToSecond * 2.0;
+    TestExecuted := TRUE;
+END_IF
+
+// Write the duration through an assert message for use by the verifier
+AssertEquals_LREAL(0, TestDuration, 0, 'Duration');
+
+TEST_FINISHED();]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="TestNamedTest20msDurationMeasuredCorrectly" Id="{e0e67c05-d34d-4254-a1f5-64b0ac92409b}">
+      <Declaration><![CDATA[METHOD TestNamedTest20msDurationMeasuredCorrectly
+VAR_INST
+    delayTimer : TON;
+END_VAR]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[TEST('TestNamedTest20msDurationMeasuredCorrectly');
+
+delayTimer(IN := TRUE, PT := T#20ms);
+
+IF delayTimer.Q THEN       
+    // Write the approximate duration through an assert message for use by the verifier
+    AssertEquals_LREAL(0, 0.02, 0, 'Duration');
+    
+    TEST_FINISHED_NAMED('TestNamedTest20msDurationMeasuredCorrectly');
+END_IF]]></ST>
+      </Implementation>
+    </Method>
+  </POU>
+</TcPlcObject>

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/PRG_TEST.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/PRG_TEST.TcPOU
@@ -24,13 +24,13 @@ VAR
     CheckIfSpecificTestIsFinished : FB_CheckIfSpecificTestIsFinished;
     WriteProtectedFunctions : FB_WriteProtectedFunctions;
     TestNumberOfAssertionsCalculation : FB_TestNumberOfAssertionsCalculation;
+    TestDurationMeasurement : FB_TestDurationMeasurement;
     TestFileControl : FB_TestFileControl;
     TestXmlControl : FB_TestXmlControl;
     TestStreamBuffer : FB_TestStreamBuffer;
     TestFinishedNamed : FB_TestFinishedNamed;
     EmptyAssertionMessage : FB_EmptyAssertionMessage;
     AssertCountExceedsMaxNumber : FB_AssertCountExceedsMaxNumber;
-
     (* The testsuite below is not active, as it will make TcUnit to abort. Uncomment if you want
        to test the function of where a test with a name that doesn't exist is set to finished *)
     //TestFinishedNamedDoesNotExist : FB_TestFinishedNamedDoesNotExist;

--- a/TcUnit/TcUnit/POUs/Functions/TEST_ORDERED.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/TEST_ORDERED.TcPOU
@@ -28,6 +28,7 @@ VAR_INPUT
 END_VAR
 VAR
     CounterTestSuiteAddress : UINT;
+    Test : REFERENCE TO FB_Test;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[TestName := F_LTrim(in := F_RTrim(in := TestName));
@@ -44,7 +45,7 @@ FOR CounterTestSuiteAddress := 1 TO GVL_TcUnit.NumberOfInitializedTestSuites BY 
 
     // Look for the test suite by comparing to the one that is currently running
     IF GVL_TcUnit.TestSuiteAddresses[CounterTestSuiteAddress] = GVL_TcUnit.CurrentTestSuiteBeingCalled THEN
-        GVL_TcUnit.TestSuiteAddresses[CounterTestSuiteAddress]^.AddTest(TestName := TestName, IsTestOrdered := TRUE);
+        Test REF= GVL_TcUnit.TestSuiteAddresses[CounterTestSuiteAddress]^.AddTest(TestName := TestName, IsTestOrdered := TRUE);
         GVL_TcUnit.CurrentTestIsFinished := GVL_TcUnit.TestSuiteAddresses[CounterTestSuiteAddress]^.IsTestFinished(TestName := TestName);
 
         // Check that no previous code has set the currently running test to ignored (for example by setting the test to DISABLED
@@ -60,7 +61,10 @@ FOR CounterTestSuiteAddress := 1 TO GVL_TcUnit.NumberOfInitializedTestSuites BY 
                     TEST_ORDERED := FALSE;
                     GVL_TcUnit.IgnoreCurrentTest := TRUE;
                 ELSE
-                    // Continue executing test
+                    // Start or continue executing test
+                    IF __ISVALIDREF(Test) THEN
+                        Test.SetStartedAtIfNotSet(Timestamp := F_GetCpuCounterAs64bit(GVL_TcUnit.GetCpuCounter));
+                    END_IF
                     TEST_ORDERED := TRUE;
                 END_IF
             ELSE

--- a/TcUnit/TcUnit/TcUnit.plcproj
+++ b/TcUnit/TcUnit/TcUnit.plcproj
@@ -15,7 +15,7 @@
     <Implicit_Jitter_Distribution>{9ba5f403-6725-42f3-958a-e49cc23e0e00}</Implicit_Jitter_Distribution>
     <LibraryReferences>{d4c50e9b-48cc-4451-9f8a-44fa2a49ee45}</LibraryReferences>
     <CombineIds>true</CombineIds>
-    <Released>false</Released>
+    <Released>true</Released>
     <Title>TcUnit</Title>
     <DefaultNamespace>TcUnit</DefaultNamespace>
     <Description>TwinCAT unit testing framework.

--- a/TcUnit/TcUnit/TcUnit.plcproj
+++ b/TcUnit/TcUnit/TcUnit.plcproj
@@ -15,7 +15,7 @@
     <Implicit_Jitter_Distribution>{9ba5f403-6725-42f3-958a-e49cc23e0e00}</Implicit_Jitter_Distribution>
     <LibraryReferences>{d4c50e9b-48cc-4451-9f8a-44fa2a49ee45}</LibraryReferences>
     <CombineIds>true</CombineIds>
-    <Released>true</Released>
+    <Released>false</Released>
     <Title>TcUnit</Title>
     <DefaultNamespace>TcUnit</DefaultNamespace>
     <Description>TwinCAT unit testing framework.
@@ -32,7 +32,7 @@ Documentation and examples are available at www.tcunit.org</Description>
     </SelectedLibraryCategories>
     <Company>www.tcunit.org</Company>
     <Author>Jakob Sagatowski and contributors</Author>
-    <ProjectVersion>1.3.0.0</ProjectVersion>
+    <ProjectVersion>1.3.0.1</ProjectVersion>
     <WriteProductVersion>false</WriteProductVersion>
     <!--    <OutputType>Exe</OutputType>
     <RootNamespace>MyApplication</RootNamespace>

--- a/TcUnit/TcUnit/TcUnit.plcproj
+++ b/TcUnit/TcUnit/TcUnit.plcproj
@@ -32,7 +32,7 @@ Documentation and examples are available at www.tcunit.org</Description>
     </SelectedLibraryCategories>
     <Company>www.tcunit.org</Company>
     <Author>Jakob Sagatowski and contributors</Author>
-    <ProjectVersion>1.3.0.1</ProjectVersion>
+    <ProjectVersion>1.3.0.0</ProjectVersion>
     <WriteProductVersion>false</WriteProductVersion>
     <!--    <OutputType>Exe</OutputType>
     <RootNamespace>MyApplication</RootNamespace>

--- a/TcUnit/TcUnit/TcUnit.plcproj
+++ b/TcUnit/TcUnit/TcUnit.plcproj
@@ -32,7 +32,7 @@ Documentation and examples are available at www.tcunit.org</Description>
     </SelectedLibraryCategories>
     <Company>www.tcunit.org</Company>
     <Author>Jakob Sagatowski and contributors</Author>
-    <ProjectVersion>1.3.1.0</ProjectVersion>
+    <ProjectVersion>1.3.2.0</ProjectVersion>
     <WriteProductVersion>false</WriteProductVersion>
     <!--    <OutputType>Exe</OutputType>
     <RootNamespace>MyApplication</RootNamespace>

--- a/TcUnit/TcUnit/Version/Global_Version.TcGVL
+++ b/TcUnit/TcUnit/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_TcUnit : ST_LibVersion := (iMajor := 1, iMinor := 3, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '1.3.0.0');
+	stLibVersion_TcUnit : ST_LibVersion := (iMajor := 1, iMinor := 3, iBuild := 0, iRevision := 0, nFlags := 1, sVersion := '1.3.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/TcUnit/TcUnit/Version/Global_Version.TcGVL
+++ b/TcUnit/TcUnit/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_TcUnit : ST_LibVersion := (iMajor := 1, iMinor := 3, iBuild := 0, iRevision := 0, nFlags := 1, sVersion := '1.3.0.0');
+	stLibVersion_TcUnit : ST_LibVersion := (iMajor := 1, iMinor := 3, iBuild := 0, iRevision := 1, nFlags := 0, sVersion := '1.3.0.1');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/TcUnit/TcUnit/Version/Global_Version.TcGVL
+++ b/TcUnit/TcUnit/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_TcUnit : ST_LibVersion := (iMajor := 1, iMinor := 3, iBuild := 1, iRevision := 0, nFlags := 1, sVersion := '1.3.1.0');
+	stLibVersion_TcUnit : ST_LibVersion := (iMajor := 1, iMinor := 3, iBuild := 2, iRevision := 0, nFlags := 1, sVersion := '1.3.2.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/TcUnit/TcUnit/Version/Global_Version.TcGVL
+++ b/TcUnit/TcUnit/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_TcUnit : ST_LibVersion := (iMajor := 1, iMinor := 3, iBuild := 0, iRevision := 1, nFlags := 0, sVersion := '1.3.0.1');
+	stLibVersion_TcUnit : ST_LibVersion := (iMajor := 1, iMinor := 3, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '1.3.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>


### PR DESCRIPTION
This PR fixes a bug with the calculation of duration on TEST_ORDERED tests, and adds TcUnit-Verifier tests to check that the duration is output within a specific range for TEST and TEST_ORDERED tests.

To determine if the duration is calculated, a new assertion is added to TcUnit.Verifier called `AssertContainsResultSet` which parses out the test result lines and checks that the duration is within a specific range.
```
Message		12/21/2023 12:13:47 PM 400 ms | 'PlcTask' (350): | Test name=TestRegularTestDurationMeasuredCorrectly				
Message		12/21/2023 12:13:47 PM 420 ms | 'PlcTask' (350): | Test class name=PRG_TEST.TestDurationMeasurement				
Message		12/21/2023 12:13:47 PM 440 ms | 'PlcTask' (350): | Test status=FAIL, number of asserts=2, duration=1.939e-4				
```

The acceptable range is based on how long the tests took to run on my system, however there is some variability in the duration and it might also depend on the target hardware. @sagatowski please check if you think this is sufficient or if you would prefer a different method.

Finally, I did not increment the version of TcUnit or TcUnit-Verifier as I wasn't sure how you want to handle this.