### PR TITLE
Documentation Update: Programming Example Broken Link

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -8,7 +8,8 @@
   - [Unit testing concepts](unit-testing-concepts.md)
   - [Introduction user guide](introduction-user-guide.md)
   - [API](api.md)
--- Programming example
+
+-- [Programming example](programming-example.md)
     - [Introduction](programming-example-introduction.md)
     - [The function blocks](programming-example-the-function-blocks.md)
     - [Test cases - Part 1](programming-example-test-cases-part-one)

--- a/docs/introduction-user-guide.md
+++ b/docs/introduction-user-guide.md
@@ -9,7 +9,7 @@ Before reading this guide, it's highly recommended to read [unit testing concept
 The TcUnit framework gives you the possibility to easily write unit tests for your TwinCAT 3 software, and having the results reported in a human-readable format for review.
 All unit test code is written in the same program/library as the rest of your code, but because it is only used in a separate test-program, it does not affect the production code/executables.
 With unit test-code provided with the rest of the code, you can see these additions as living documentation of the code.
-For a more thorough/detailed example please see the [programming example](programming-example.md).
+For a more thorough/detailed example please see the [programming example](programming-example-introduction.md).
 
 The purpose of this user guide is to be a short tutorial where we will go through the different steps to that are necessary to use TcUnit, which are:
 

--- a/docs/introduction-user-guide.md
+++ b/docs/introduction-user-guide.md
@@ -9,7 +9,7 @@ Before reading this guide, it's highly recommended to read [unit testing concept
 The TcUnit framework gives you the possibility to easily write unit tests for your TwinCAT 3 software, and having the results reported in a human-readable format for review.
 All unit test code is written in the same program/library as the rest of your code, but because it is only used in a separate test-program, it does not affect the production code/executables.
 With unit test-code provided with the rest of the code, you can see these additions as living documentation of the code.
-For a more thorough/detailed example please see the [programming example](programming-example-introduction.md).
+For a more thorough/detailed example please see the [programming example](programming-example.md).
 
 The purpose of this user guide is to be a short tutorial where we will go through the different steps to that are necessary to use TcUnit, which are:
 

--- a/docs/programming-example.md
+++ b/docs/programming-example.md
@@ -1,0 +1,16 @@
+# Programming Example
+
+<p align="center">
+  <img width="1024" src="./img/tc3_banner.jpg">
+</p>
+
+
+## Overview:
+
+- [Introduction](programming-example-introduction.md)
+- [The function blocks](programming-example-the-function-blocks.md)
+- [Test cases - Part 1](programming-example-test-cases-part-one)
+- [Test cases - Part 2](programming-example-test-cases-part-two)
+- [Implementation - Part 1](programming-example-implementation-part-one.md)
+- [Implementation - Part 2](programming-example-implementation-part-two.md)
+- [Final words](programming-example-final-words.md)


### PR DESCRIPTION
There is/was a broken link to the Programming Example in the Documentation Intro User Guide Documentation: https://github.com/tcunit/TcUnit/blob/8f0ecba128b430b297cf8bd95faabd78a1495bf3/docs/introduction-user-guide.md?plain=1#L12

That page was renamed to [programming-example-test-cases-part-two.md](https://github.com/tcunit/TcUnit/commit/c46727696263f79ac39df1c23ecf9d48b0c3e1d3#diff-79f1814c89aecb51d2cea3d96420eee17d1cfe719164f522edd1f8aeb1e64bcd) in https://github.com/tcunit/TcUnit/commit/c46727696263f79ac39df1c23ecf9d48b0c3e1d3#diff-79f1814c89aecb51d2cea3d96420eee17d1cfe719164f522edd1f8aeb1e64bcd