### PR TITLE
Escape some characters in xunit_results.xml

### DIFF
--- a/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_TestXUnitPublisher.cs
+++ b/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/FB_TestXUnitPublisher.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace TcUnit.Verifier
+{
+    class FB_TestXUnitPublisher : TestFunctionBlockAssert
+    {
+        public FB_TestXUnitPublisher(IEnumerable<ErrorList.Error> errors, string xmlTestResultsFilePath, string testFunctionBlockInstance = null)
+            : base(errors, testFunctionBlockInstance)
+        {
+            Test_ParceXml(xmlTestResultsFilePath);
+            Test_EscapedFailedMessage();
+            Test_EscapedFunctionName();
+        }
+        private void Test_ParceXml(string xmlTestResultsFilePath)
+        {
+            try
+            {
+                XDocument _ = XDocument.Load(xmlTestResultsFilePath);
+            }
+            catch (Exception)
+            {
+                log.Info("Test suite " + _testFunctionBlockInstance + " could not parse xml file: " + xmlTestResultsFilePath);
+            }
+            
+        }
+        private void Test_EscapedFailedMessage()
+        {
+            string testMessage = "PRG_TEST." + _testFunctionBlockInstance + "@Test_EscapedFailedMessage";
+            AssertContainsMessage(testMessage, EnvDTE80.vsBuildErrorLevel.vsBuildErrorLevelHigh);
+        }
+  
+        private void Test_EscapedFunctionName()
+        {
+            string testMessage = "PRG_TEST." + _testFunctionBlockInstance + "@Test_EscapedFunctionName";
+            AssertDoesNotContainMessage(testMessage, EnvDTE80.vsBuildErrorLevel.vsBuildErrorLevelHigh);
+        }
+    }
+}

--- a/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/Program.cs
+++ b/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/Program.cs
@@ -1,4 +1,4 @@
-﻿using NDesk.Options;
+using NDesk.Options;
 using log4net;
 using System;
 using System.Collections.Generic;
@@ -16,9 +16,10 @@ namespace TcUnit.Verifier
     {
         private static string tcUnitVerifierPath = null;
         private static string tcUnitTargetNetId = "127.0.0.1.1.1";
+        private static string tcUnitXUnitFilePath = @"C:\TwinCAT\3.1\Boot\tcunit_xunit_testresults.xml";
         private static VisualStudioInstance vsInstance = null;
         private static ILog log = LogManager.GetLogger("TcUnit-Verifier");
-        private static int expectedNumberOfFailedTests = 121; // Update this if you add intentionally failing tests
+        private static int expectedNumberOfFailedTests = 122; // Update this if you add intentionally failing tests
 
         [STAThread]
         static void Main(string[] args)
@@ -31,6 +32,7 @@ namespace TcUnit.Verifier
             OptionSet options = new OptionSet()
                 .Add("v=|TcUnitVerifierPath=", "Path to TcUnit-Verifier TwinCAT solution", v => tcUnitVerifierPath = v)
                 .Add("t=|TcUnitTargetNetId=", "[OPTIONAL] Target NetId of TwinCAT runtime to run TcUnit-Verifier", t => tcUnitTargetNetId = t)
+                .Add("x=|TcUnitXUnitFilePath=", "[OPTIONAL] path and filename for the TcUnit-Verifier xunit testresults", t => tcUnitXUnitFilePath = t)
                 .Add("?|h|help", h => showHelp = h != null);
 
             try
@@ -213,6 +215,7 @@ namespace TcUnit.Verifier
             new FB_TestDurationMeasurement(errors);
             new FB_EmptyAssertionMessage(errors);
             new FB_AssertCountExceedsMaxNumber(errors);
+            new FB_TestXUnitPublisher(errors, tcUnitXUnitFilePath);
 
             log.Info("Done.");
 

--- a/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/TcUnit-Verifier.csproj
+++ b/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/TcUnit-Verifier.csproj
@@ -59,6 +59,7 @@
     <Compile Include="FB_AssertCountExceedsMaxNumber.cs" />
     <Compile Include="FB_EmptyAssertionMessage.cs" />
     <Compile Include="FB_TestDurationMeasurement.cs" />
+    <Compile Include="FB_TestXUnitPublisher.cs" />
     <Compile Include="FB_TestXmlControl.cs" />
     <Compile Include="FB_TestFileControl.cs" />
     <Compile Include="FB_TestStreamBuffer.cs" />

--- a/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/TestFunctionBlockAssert.cs
+++ b/TcUnit-Verifier/TcUnit-Verifier_DotNet/TcUnit-Verifier/TestFunctionBlockAssert.cs
@@ -10,7 +10,7 @@ namespace TcUnit.Verifier
     {
         private IEnumerable<ErrorList.Error> _errors;
         protected string _testFunctionBlockInstance;
-        private static ILog log = LogManager.GetLogger("TcUnit-Verifier");
+        protected static ILog log = LogManager.GetLogger("TcUnit-Verifier");
 
         private string DefaultFunctionBlockInstance
         {

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/TcUnitVerifier.plcproj
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/TcUnitVerifier.plcproj
@@ -104,6 +104,9 @@
     <Compile Include="Test\FB_TestXmlControl.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Test\FB_TestXUnitPublisher.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Test\FB_WriteProtectedFunctions.TcPOU">
       <SubType>Code</SubType>
     </Compile>
@@ -146,6 +149,12 @@
     <PlaceholderReference Include="TcUnit">
       <DefaultResolution>TcUnit, * (www.tcunit.org)</DefaultResolution>
       <Namespace>TcUnit</Namespace>
+      <Parameters>
+        <Parameter ListName="GVL_PARAM_TCUNIT" xmlns="">
+          <Key>XUNITENABLEPUBLISH</Key>
+          <Value>TRUE</Value>
+        </Parameter>
+      </Parameters>
     </PlaceholderReference>
   </ItemGroup>
   <ItemGroup>

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestXUnitPublisher.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/FB_TestXUnitPublisher.TcPOU
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_TestXUnitPublisher" Id="{c7819ac2-5de4-4840-89ae-815e54b5cb69}" SpecialFunc="None">
+    <Declaration><![CDATA[// Contains tests that verify the XmlControl function block methods
+FUNCTION_BLOCK FB_TestXUnitPublisher EXTENDS TcUnit.FB_TestSuite]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[Test_EscapedFailedMessage();
+Test_EscapedFunctionName();]]></ST>
+    </Implementation>
+    <Method Name="Test_EscapedFailedMessage" Id="{8aca4c27-6db1-484c-a76f-a529f691497e}">
+      <Declaration><![CDATA[METHOD PRIVATE Test_EscapedFailedMessage]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[TEST('Test_EscapedFailedMessage');
+
+AssertTrue(FALSE, 'This "string" <should> be $'escaped$' & parsed properly');
+
+TEST_FINISHED();]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="Test_EscapedFunctionName" Id="{da2058a6-4b6f-43f7-8364-e0cf3494d96b}">
+      <Declaration><![CDATA[METHOD PRIVATE Test_EscapedFunctionName]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[TEST('Test_EscapedFunctionName$'"<>&');
+
+TEST_FINISHED();]]></ST>
+      </Implementation>
+    </Method>
+  </POU>
+</TcPlcObject>

--- a/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/PRG_TEST.TcPOU
+++ b/TcUnit-Verifier/TcUnit-Verifier_TwinCAT/TcUnit-Verifier_TwinCAT/TcUnitVerifier/Test/PRG_TEST.TcPOU
@@ -31,6 +31,7 @@ VAR
     TestFinishedNamed : FB_TestFinishedNamed;
     EmptyAssertionMessage : FB_EmptyAssertionMessage;
     AssertCountExceedsMaxNumber : FB_AssertCountExceedsMaxNumber;
+    TestXUnitPublisher : FB_TestXUnitPublisher;
     (* The testsuite below is not active, as it will make TcUnit to abort. Uncomment if you want
        to test the function of where a test with a name that doesn't exist is set to finished *)
     //TestFinishedNamedDoesNotExist : FB_TestFinishedNamedDoesNotExist;

--- a/TcUnit/TcUnit/POUs/FB_xUnitXmlPublisher.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_xUnitXmlPublisher.TcPOU
@@ -115,7 +115,7 @@ IF PublishTrigger.Q THEN
         FOR CurrentTestCount := 1 TO UnitTestResults.TestSuiteResults[CurrentSuiteNumber].NumberOfTests BY 1 DO
             // <testcase>
             Xml.NewTag('testcase');
-            Xml.NewParameter('name', UnitTestResults.TestSuiteResults[CurrentSuiteNumber].TestCaseResults[CurrentTestCount].TestName);
+            Xml.NewParameter('name', F_XmlEscapeString(UnitTestResults.TestSuiteResults[CurrentSuiteNumber].TestCaseResults[CurrentTestCount].TestName));
             Xml.NewParameter('classname', UnitTestResults.TestSuiteResults[CurrentSuiteNumber].TestCaseResults[CurrentTestCount].TestClassName);
             Xml.NewParameter('time', LREAL_TO_STRING(UnitTestResults.TestSuiteResults[CurrentSuiteNumber].TestCaseResults[CurrentTestCount].Duration));
 
@@ -133,7 +133,7 @@ IF PublishTrigger.Q THEN
                     <failure message="Values differ" type="BYTE" />
                 *)
                 Xml.NewTag('failure');
-                Xml.NewParameter('message', UnitTestResults.TestSuiteResults[CurrentSuiteNumber].TestCaseResults[CurrentTestCount].FailureMessage);
+                Xml.NewParameter('message', F_XmlEscapeString(UnitTestResults.TestSuiteResults[CurrentSuiteNumber].TestCaseResults[CurrentTestCount].FailureMessage));
                 Xml.NewParameter('type', F_AssertionTypeToString(UnitTestResults.TestSuiteResults[CurrentSuiteNumber].TestCaseResults[CurrentTestCount].FailureType));       
                 // Close failure tag
                 Xml.CloseTag();

--- a/TcUnit/TcUnit/POUs/Functions/F_XmlEscapeString.TcPOU
+++ b/TcUnit/TcUnit/POUs/Functions/F_XmlEscapeString.TcPOU
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="F_XmlEscapeString" Id="{5bc10c6a-24ec-0a65-0666-70c1e69087d6}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION F_XmlEscapeString : T_MaxString
+VAR_INPUT
+	Message : T_MaxString;
+END_VAR
+VAR	
+	EscapedMessage : T_MaxString;
+	EscapedMessageSize : UDINT := SIZEOF(T_MaxString);
+END_VAR
+VAR CONSTANT
+	QUOTE : STRING(1) := '"';
+	APOS : STRING(2) := '$'';
+	_LT : STRING(1) := '<';
+	_GT : STRING(1) := '>';
+	AMP : STRING(1) := '&';
+	
+	ESCAPED_QUOTE : STRING(6) := '&quot;';
+	ESCAPED_APOS : STRING(6) := '&apos;';
+	ESCAPED_LT : STRING(4) := '&lt;';
+	ESCAPED_GT : STRING(4) := '&gt;';
+	ESCAPED_AMP : STRING(5) := '&amp;';
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[EscapedMessage := Message;
+FindAndReplace(ADR(EscapedMessage), ADR(AMP), ADR(ESCAPED_AMP), ADR(EscapedMessage), SIZEOF(T_MaxString));
+FindAndReplace(ADR(EscapedMessage), ADR(QUOTE), ADR(ESCAPED_QUOTE), ADR(EscapedMessage), SIZEOF(T_MaxString));
+FindAndReplace(ADR(EscapedMessage), ADR(APOS), ADR(ESCAPED_APOS), ADR(EscapedMessage), SIZEOF(T_MaxString));
+FindAndReplace(ADR(EscapedMessage), ADR(_LT), ADR(ESCAPED_LT), ADR(EscapedMessage), SIZEOF(T_MaxString));
+FindAndReplace(ADR(EscapedMessage), ADR(_GT), ADR(ESCAPED_GT), ADR(EscapedMessage), SIZEOF(T_MaxString));
+F_XmlEscapeString := EscapedMessage;]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/TcUnit/TcUnit/TcUnit.plcproj
+++ b/TcUnit/TcUnit/TcUnit.plcproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>-->
@@ -159,6 +159,9 @@ Documentation and examples are available at www.tcunit.org</Description>
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Functions\F_RemoveInstancePathAndProjectNameFromTestInstancePath.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Functions\F_XmlEscapeString.TcPOU">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Functions\IS_TEST_FINISHED.TcPOU">


### PR DESCRIPTION
Hi,

First of all we love your work! We are using your framework for some time now and found a problem with the xml results.

Assert Messages and TestNames are not properly escaped in the xunit_testresults.xml

If you would add a " character in either the Assert Message or TestName the xunit_testresults.xml cannot be properly parsed by xml parsers. To fix this problem I've implemented a F_XmlEscapeString function. For now I followed the 'safe' approach as suggested in this link https://stackoverflow.com/a/1091953.

Sample test code that will create the problem in the xml file:
```
TEST('Test_EscapedFailedMessage');
AssertTrue(FALSE, 'This "string" <should> be $'escaped$' & parsed properly');
TEST_FINISHED();

TEST('Test_EscapedFunctionName$'"<>&');
TEST_FINISHED();
```

These tests result in:
```
<?xml version="1.0" encoding="UTF-8"?>
<testsuites disabled="" failures="1" tests="2" time="8.38e-5">
	<testsuite id="26" name="PRG_TEST.TestXUnitPublisher" tests="2" failures="1" time="7.47e-5">
		<testcase name="Test_EscapedFailedMessage" classname="PRG_TEST.TestXUnitPublisher" time="6.15e-5" status="FAIL">
			<failure message="This " string"
			<should> be 'escaped' & parsed properly" type="BOOL"/></testcase>
			<testcase name="Test_EscapedFunctionName'"
			<>&" classname="PRG_TEST.TestXUnitPublisher" time="1.0e-7" status="PASS"></testcase>
		</testsuite>
	</testsuites>
```

But should be:
```
<?xml version="1.0" encoding="UTF-8"?>
<testsuites disabled="" failures="1" tests="2" time="3.602e-4">
	<testsuite id="26" name="PRG_TEST.TestXUnitPublisher" tests="2" failures="1" time="3.602e-4">
		<testcase name="Test_EscapedFailedMessage" classname="PRG_TEST.TestXUnitPublisher" time="3.351e-4" status="FAIL">
			<failure message="This &quot;string&quot; &lt;should&gt; be &apos;escaped&apos; &amp; parsed properly" type="BOOL"/>
		</testcase>
		<testcase name="Test_EscapedFunctionName&apos;&quot;&lt;&gt;&amp;" classname="PRG_TEST.TestXUnitPublisher" time="1.0e-7" status="PASS"/>
	</testsuite>
</testsuites>
```

I've tried to add some basic tests, but I'm not happy with the requirement that is now should be run on a local machine for this to work. I'm happy to omit these tests or adjust this if needed.

Please let me know what you think of this change.

(Note: this is the first time I'm actively contributing to a project, so please let me know if I should do anything different next time :) )