### PR TITLE
feat: allow to disable the ads logger completely

### DIFF
--- a/TcUnit/TcUnit/GVLs/GVL_Param_TcUnit.TcGVL
+++ b/TcUnit/TcUnit/GVLs/GVL_Param_TcUnit.TcGVL
@@ -6,16 +6,18 @@ VAR_GLOBAL CONSTANT
     MaxNumberOfTestSuites : UINT := 1000;
     MaxNumberOfTestsForEachTestSuite : UINT := 100;
     MaxNumberOfAssertsForEachTestSuite : UINT := 1000;
-
+    
     (* TcUnit logs complete test results. These include:
-         - Number of test suites
-         - Number of tests
-         - Number of successful tests
-         - Number of failed tests
-         - Any eventual failed assertion (with the expected & actual value plus an user defined message)
-       These are all printed to the ADS logger (Visual Studio error list) marked with ERROR criticality
+       - Number of test suites
+       - Number of tests
+       - Number of successful tests
+       - Number of failed tests
+       - Any eventual failed assertion (with the expected & actual value plus an user defined message)
+       These are all printed to the ADS logger (Visual Studio error list) marked with ERROR criticality *)
+    AdsLoggerEnablePublish : BOOL := TRUE;
 
-       On top of this TcUnit also reports some statistics/extended information with HINT/INFO criticality.
+
+    (* On top of the normal result, TcUnit also reports some statistics/extended information with HINT/INFO criticality.
        These statistics are more detailed results of the tests. This information is used when results are
        being collected by an external software (such as TcUnit-Runner) to do for example Jenkins integration.
        This extra information however takes time to print, so by setting the following parameter to FALSE

--- a/TcUnit/TcUnit/POUs/FB_AdsLogStringMessageFifoQueue.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_AdsLogStringMessageFifoQueue.TcPOU
@@ -74,7 +74,7 @@ VAR
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Only log message types of ERROR if log extended results is not enabled
-IF MsgCtrlMask = ADSLOG_MSGTYPE_ERROR OR GVL_Param_TcUnit.LogExtendedResults THEN
+IF GVL_Param_TcUnit.AdsLoggerEnablePublish AND_THEN (MsgCtrlMask = ADSLOG_MSGTYPE_ERROR OR GVL_Param_TcUnit.LogExtendedResults) THEN
     AdsLogStringMessage.MsgCtrlMask := MsgCtrlMask;
     AdsLogStringMessage.MsgFmtStr := MsgFmtStr;
     AdsLogStringMessage.StrArg := StrArg;

--- a/TcUnit/TcUnit/POUs/FB_AdsTestResultLogger.TcPOU
+++ b/TcUnit/TcUnit/POUs/FB_AdsTestResultLogger.TcPOU
@@ -50,7 +50,7 @@ END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[TcUnitTestResults REF= TestResults.GetTestSuiteResults();
 
-IF PrintingTestSuiteResultNumber <= GVL_TcUnit.NumberOfInitializedTestSuites AND NOT PrintedTestSuitesResults THEN
+IF PrintingTestSuiteResultNumber <= GVL_TcUnit.NumberOfInitializedTestSuites AND_THEN NOT PrintedTestSuitesResults THEN
     PrintingTestSuiteTrigger(CLK := GVL_TcUnit.TestSuiteAddresses[PrintingTestSuiteResultNumber]^.AreAllTestsFinished());
     IF PrintingTestSuiteTrigger.Q THEN
         StringToPrint := CONCAT(STR1 := '| Test suite ID=',


### PR DESCRIPTION
While the ADS Logger is the easiest way to immediately see the test results, there are other means, which can be visualized better than the Visual Studio Output. For instance, the xml file can be used to generate a nice view, or the results can be read directly via an ADS client.
Also, especially if a solution has many project, the Output multiplies and there is no workaround for this.

For this reason, I added a switch to make it simple to optionally switch off the ADS Logger